### PR TITLE
ROFO-27 검색 기록 저장 기능

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -49,5 +49,6 @@ dependencies {
     implementation(libs.retrofit2.converter.scalars)
     implementation(libs.okhttp3.logging.interceptor)
     implementation(libs.kakao.login)
+    implementation(libs.datastore.preferences)
     testImplementation(libs.junit)
 }

--- a/data/src/main/java/com/weit2nd/data/di/SearchHistoryModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/SearchHistoryModule.kt
@@ -1,0 +1,33 @@
+package com.weit2nd.data.di
+
+import android.content.Context
+import com.weit2nd.data.repository.searchhistory.SearchHistoryRepositoryImpl
+import com.weit2nd.data.source.SearchHistoryDataSource
+import com.weit2nd.domain.repository.searchhistory.SearchHistoryRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.scopes.ViewModelScoped
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object SearchHistoryModule {
+
+    @ViewModelScoped
+    @Provides
+    fun providesSearchHistoryRepository(
+        dataSource: SearchHistoryDataSource,
+    ): SearchHistoryRepository {
+        return SearchHistoryRepositoryImpl(dataSource)
+    }
+
+    @ViewModelScoped
+    @Provides
+    fun providesSearchHistoryDataSource(
+        @ApplicationContext context: Context,
+    ): SearchHistoryDataSource {
+        return SearchHistoryDataSource(context)
+    }
+}

--- a/data/src/main/java/com/weit2nd/data/repository/searchhistory/SearchHistoryRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/searchhistory/SearchHistoryRepositoryImpl.kt
@@ -13,8 +13,10 @@ class SearchHistoryRepositoryImpl @Inject constructor(
 
     override suspend fun addSearchHistory(searchWord: String) {
         val newHistories = dataSource.getSearchHistories().toMutableList()
-        if (newHistories.contains(searchWord)) {
-            newHistories.remove(searchWord)
+        // 넣으려는 검색어가 첫번째에 있다면 동작이 불필요하기 때문에 패스
+        val targetIndex = newHistories.indexOf(searchWord).takeIf { it != 0 } ?: return
+        if (targetIndex != -1) {
+            newHistories.removeAt(targetIndex)
         }
         newHistories.add(0, searchWord)
         dataSource.setSearchHistory(newHistories)

--- a/data/src/main/java/com/weit2nd/data/repository/searchhistory/SearchHistoryRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/searchhistory/SearchHistoryRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package com.weit2nd.data.repository.searchhistory
+
+import com.weit2nd.data.source.SearchHistoryDataSource
+import com.weit2nd.domain.repository.searchhistory.SearchHistoryRepository
+import javax.inject.Inject
+
+class SearchHistoryRepositoryImpl @Inject constructor(
+    private val dataSource: SearchHistoryDataSource,
+) : SearchHistoryRepository {
+    override suspend fun getSearchHistories(): List<String> {
+        return dataSource.getSearchHistories()
+    }
+
+    override suspend fun addSearchHistory(searchWord: String) {
+        val newHistories = dataSource.getSearchHistories().toMutableList()
+        if (newHistories.contains(searchWord)) {
+            newHistories.remove(searchWord)
+        }
+        newHistories.add(0, searchWord)
+        dataSource.setSearchHistory(newHistories)
+    }
+
+    override suspend fun removeSearchHistory(searchWord: String) {
+        val newHistories = dataSource.getSearchHistories().minus(searchWord)
+        dataSource.setSearchHistory(newHistories)
+    }
+
+    override suspend fun clearSearchHistory() {
+        dataSource.setSearchHistory(emptyList())
+    }
+}

--- a/data/src/main/java/com/weit2nd/data/repository/searchhistory/SearchHistoryRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/searchhistory/SearchHistoryRepositoryImpl.kt
@@ -16,6 +16,12 @@ class SearchHistoryRepositoryImpl @Inject constructor(
         // 넣으려는 검색어가 첫번째에 있다면 동작이 불필요하기 때문에 패스
         val targetIndex = newHistories.indexOf(searchWord).takeIf { it != 0 } ?: return
         if (targetIndex != -1) {
+            // 순서가 달라도 같은 요소가 들어있다면 DataStore는 같은 데이터로 인식해 갱신을 안한다.
+            // 그래서 갱신전에 한번 clear를 함
+            // TODO: 6/12/24 (minseong1231) clear 동작을 DataSource로 이동하기
+            // dataSource의 동작을 알기 때문에 이런 동작을 할 수 있는건데 되게 쿨하지 않음
+            // 성능을 챙기면서 로직을 옮길 수 있는 멋진 방법을 생각해보자
+            clearSearchHistory()
             newHistories.removeAt(targetIndex)
         }
         newHistories.add(0, searchWord)

--- a/data/src/main/java/com/weit2nd/data/source/SearchHistoryDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/SearchHistoryDataSource.kt
@@ -1,0 +1,42 @@
+package com.weit2nd.data.source
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class SearchHistoryDataSource @Inject constructor(
+    private val context: Context,
+) {
+
+    private val Context.placeSearchHistoryDataStore: DataStore<Preferences> by preferencesDataStore(
+        name = "searchHistory"
+    )
+
+    suspend fun getSearchHistories(): List<String> {
+        return context.placeSearchHistoryDataStore.data
+            .catch {
+                emit(emptyPreferences())
+            }
+            .map { preference ->
+                preference[KEY_SEARCH_HISTORY] ?: emptyList()
+            }.first().toList()
+    }
+
+    suspend fun setSearchHistory(searchWords: List<String>) {
+        context.placeSearchHistoryDataStore.edit { preference ->
+            preference[KEY_SEARCH_HISTORY] = searchWords.toSet()
+        }
+    }
+
+    private companion object{
+        val KEY_SEARCH_HISTORY = stringSetPreferencesKey(name = "search_history")
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/repository/searchhistory/SearchHistoryRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/searchhistory/SearchHistoryRepository.kt
@@ -1,0 +1,9 @@
+package com.weit2nd.domain.repository.searchhistory
+
+interface SearchHistoryRepository {
+
+    suspend fun getSearchHistories(): List<String>
+    suspend fun addSearchHistory(searchWord: String)
+    suspend fun removeSearchHistory(searchWord: String)
+    suspend fun clearSearchHistory()
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/searchhistory/AddSearchHistoriesUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/searchhistory/AddSearchHistoriesUseCase.kt
@@ -1,0 +1,18 @@
+package com.weit2nd.domain.usecase.searchhistory
+
+import com.weit2nd.domain.repository.searchhistory.SearchHistoryRepository
+import javax.inject.Inject
+
+class AddSearchHistoriesUseCase @Inject constructor(
+    private val repository: SearchHistoryRepository,
+) {
+    /**
+     * 검색 기록을 추가 합니다.
+     * 검색 기록은 리스트의 첫번째 index에 추가됩니다.
+     *
+     * 이미 존재하는 기록 이라면 해당 요소의 position을 첫번째로 옮깁니다.
+     */
+    suspend operator fun invoke(searchWord: String) {
+        repository.addSearchHistory(searchWord)
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/searchhistory/ClearSearchHistoriesUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/searchhistory/ClearSearchHistoriesUseCase.kt
@@ -1,0 +1,15 @@
+package com.weit2nd.domain.usecase.searchhistory
+
+import com.weit2nd.domain.repository.searchhistory.SearchHistoryRepository
+import javax.inject.Inject
+
+class ClearSearchHistoriesUseCase @Inject constructor(
+    private val repository: SearchHistoryRepository,
+) {
+    /**
+     * 모든 검색 기록을 정리합니다.
+     */
+    suspend operator fun invoke() {
+        repository.clearSearchHistory()
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/searchhistory/GetSearchHistoriesUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/searchhistory/GetSearchHistoriesUseCase.kt
@@ -1,0 +1,15 @@
+package com.weit2nd.domain.usecase.searchhistory
+
+import com.weit2nd.domain.repository.searchhistory.SearchHistoryRepository
+import javax.inject.Inject
+
+class GetSearchHistoriesUseCase @Inject constructor(
+    private val repository: SearchHistoryRepository,
+) {
+    /**
+     * 최근에 추가된 기록 순서로 정렬된 검색 기록 리스트를 가져옵니다.
+     */
+    suspend operator fun invoke(): List<String> {
+        return repository.getSearchHistories()
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/searchhistory/RemoveSearchHistoriesUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/searchhistory/RemoveSearchHistoriesUseCase.kt
@@ -1,0 +1,15 @@
+package com.weit2nd.domain.usecase.searchhistory
+
+import com.weit2nd.domain.repository.searchhistory.SearchHistoryRepository
+import javax.inject.Inject
+
+class RemoveSearchHistoriesUseCase @Inject constructor(
+    private val repository: SearchHistoryRepository,
+) {
+    /**
+     * 검색 기록을 제거 합니다.
+     */
+    suspend operator fun invoke(searchWord: String) {
+        repository.removeSearchHistory(searchWord)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ converterScalars = "2.9.0"
 ksp = "1.8.10-1.0.9"
 kakaoSdk = "2.20.1"
 collectionsImmutable = "0.3.7"
+datastorePreferences = "1.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -71,6 +72,7 @@ moshi = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "mo
 moshiCodegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshi" }
 kakao-map = { module = "com.kakao.maps.open:android", name = "kakaoMap", version.ref = "kakaoMap" }
 kakao-login = { module = "com.kakao.sdk:v2-user", version.ref = "kakaoSdk" }
+datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences"}
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
### 개요
* 검색 기록 관리 기능 추가

### 변경사항
- 검색 기록 관리 기능 추가
  - DataStore를 활용해 문자열 데이터를 추가, 삭제, 리스트로 조회하는 기능을 만들었읍니다.

### 관련 지라 및 위키 링크
 - [ROFO-27](https://weit-2nd.atlassian.net/browse/ROFO-27) 


### 리뷰어에게 하고 싶은 말
- 딱히 읍슴

[ROFO-27]: https://weit-2nd.atlassian.net/browse/ROFO-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ