### PR TITLE
ROFO-33 사진 webp 포맷팅

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -50,5 +50,6 @@ dependencies {
     implementation(libs.okhttp3.logging.interceptor)
     implementation(libs.kakao.login)
     implementation(libs.datastore.preferences)
+    implementation(libs.androidx.exifinterface)
     testImplementation(libs.junit)
 }

--- a/data/src/main/java/com/weit2nd/data/util/BitmapUtil.kt
+++ b/data/src/main/java/com/weit2nd/data/util/BitmapUtil.kt
@@ -60,6 +60,10 @@ private fun getScaledWidthAndHeight(
  * @param degree 회전 각도
  */
 fun Bitmap.getRotatedBitmap(degree: Float): Bitmap {
-    val matrix = Matrix().apply { postRotate(degree) }
-    return Bitmap.createBitmap(this, 0, 0, width, height, matrix, true) ?: this
+    return if (degree != 0f) {
+        val matrix = Matrix().apply { postRotate(degree) }
+        Bitmap.createBitmap(this, 0, 0, width, height, matrix, true)
+    } else {
+        this
+    }
 }

--- a/data/src/main/java/com/weit2nd/data/util/BitmapUtil.kt
+++ b/data/src/main/java/com/weit2nd/data/util/BitmapUtil.kt
@@ -1,0 +1,65 @@
+package com.weit2nd.data.util
+
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.os.Build
+import androidx.annotation.IntRange
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+
+private const val DEFAULT_QUALITY = 90
+private const val DEFAULT_RESIZE = 1024
+
+/**
+ * Bitmap을 Webp로 압축한 ByteArray를 반환 합니다.
+ * @param quality 압축 품질
+ */
+suspend fun Bitmap.getCompressedBytes(
+    @IntRange(from = 1, to = 100) quality: Int = DEFAULT_QUALITY,
+): ByteArray =
+    withContext(Dispatchers.IO) {
+        ByteArrayOutputStream().use { outputStream ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                compress(Bitmap.CompressFormat.WEBP_LOSSY, quality, outputStream)
+            } else {
+                compress(Bitmap.CompressFormat.WEBP, quality, outputStream)
+            }
+            outputStream.toByteArray()
+        }
+    }
+
+/**
+ * Bitmap의 width, height 모두 maximumSize 보다 크다면
+ * width, height 중 크기가 작은 값을 maximumSize로 잡고 비율에 맞게 리사이징을 합니다.
+ */
+suspend fun Bitmap.getScaledBitmap(
+    maximumSize: Int = DEFAULT_RESIZE,
+): Bitmap =
+    withContext(Dispatchers.IO) {
+        val (width, height) = getScaledWidthAndHeight(
+            width = width,
+            height = height,
+            maximumSize = maximumSize,
+        )
+        Bitmap.createScaledBitmap(this@getScaledBitmap, width, height, false)
+    }
+
+private fun getScaledWidthAndHeight(
+    width: Int,
+    height: Int,
+    maximumSize: Int,
+) = when {
+    width in maximumSize until height -> maximumSize to (maximumSize / width.toFloat() * height).toInt()
+    height in maximumSize until width -> (maximumSize / height.toFloat() * height).toInt() to maximumSize
+    else -> width to height
+}
+
+/**
+ * 회전한 Bitmap을 반환 합니다.
+ * @param degree 회전 각도
+ */
+fun Bitmap.getRotatedBitmap(degree: Float): Bitmap {
+    val matrix = Matrix().apply { postRotate(degree) }
+    return Bitmap.createBitmap(this, 0, 0, width, height, matrix, true) ?: this
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ ksp = "1.8.10-1.0.9"
 kakaoSdk = "2.20.1"
 collectionsImmutable = "0.3.7"
 datastorePreferences = "1.0.0"
+exifinterface = "1.3.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -73,6 +74,7 @@ moshiCodegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", ve
 kakao-map = { module = "com.kakao.maps.open:android", name = "kakaoMap", version.ref = "kakaoMap" }
 kakao-login = { module = "com.kakao.sdk:v2-user", version.ref = "kakaoSdk" }
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences"}
+androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
### 개요
* 이미지 webp 변환 기능 추가

### 변경사항
- 로컬 이미지 uri을 받으면 webp로 포맷팅한 이미지의 ByteArray를 반환하는 메소드 추가

### 관련 지라 및 위키 링크
 - [ROFO-33](https://weit-2nd.atlassian.net/browse/ROFO-33) 

### 리뷰어에게 하고 싶은 말
* 사진을 서버로 보낼 때 꼭 필요한 작업 중 하나 임니다


[ROFO-33]: https://weit-2nd.atlassian.net/browse/ROFO-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ