### PR TITLE
ROFO-39 Storage Access Framework 기능 Data 모듈로 분리

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.jetbrainsKotlinAndroid)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.hiltAndroid)
     kotlin("kapt")
 }
 
@@ -39,6 +39,7 @@ android {
 dependencies {
     implementation(project(":domain"))
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.activity.compose)
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
     implementation(libs.kotlinx.coroutines.android)

--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -1,2 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <application>
+        <activity
+            android:name=".source.pickimage.PickImageActivity"
+            android:exported="true"
+            android:theme="@style/TransparentCompat"/>
+    </application>
+</manifest>

--- a/data/src/main/java/com/weit2nd/data/di/PickImageModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/PickImageModule.kt
@@ -1,0 +1,32 @@
+package com.weit2nd.data.di
+
+import com.weit2nd.data.repository.pickimage.PickImageRepositoryImpl
+import com.weit2nd.data.source.pickimage.PickImageDataSource
+import com.weit2nd.data.util.ActivityProvider
+import com.weit2nd.domain.repository.pickimage.PickImageRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PickImageModule {
+
+    @Singleton
+    @Provides
+    fun providesPickImageRepository(
+        dataSource: PickImageDataSource,
+    ): PickImageRepository {
+        return PickImageRepositoryImpl(dataSource)
+    }
+
+    @Singleton
+    @Provides
+    fun providesPickImageDataSource(
+        activityProvider: ActivityProvider,
+    ): PickImageDataSource {
+        return PickImageDataSource(activityProvider)
+    }
+}

--- a/data/src/main/java/com/weit2nd/data/repository/pickimage/PickImageRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/pickimage/PickImageRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package com.weit2nd.data.repository.pickimage
+
+import com.weit2nd.data.source.pickimage.PickImageDataSource
+import com.weit2nd.domain.repository.pickimage.PickImageRepository
+import javax.inject.Inject
+
+class PickImageRepositoryImpl @Inject constructor(
+    private val dataSource: PickImageDataSource,
+) : PickImageRepository {
+    override suspend fun pickImage(): String? {
+        return dataSource.pickImage()?.toString()
+    }
+
+    override suspend fun pickImages(maximumSelect: Int): List<String> {
+        return dataSource.pickImages(maximumSelect).map { it.toString() }
+    }
+
+}

--- a/data/src/main/java/com/weit2nd/data/source/pickimage/PickImageActivity.kt
+++ b/data/src/main/java/com/weit2nd/data/source/pickimage/PickImageActivity.kt
@@ -1,0 +1,47 @@
+package com.weit2nd.data.source.pickimage
+
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class PickImageActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var pickImageDataSource: PickImageDataSource
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val maximumSelect = intent.getIntExtra(MAXIMUM_SELECT_KEY, 1)
+        val pickMedia = if (maximumSelect > 1) {
+            registerForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(maximumSelect)) { images ->
+                sendSelectedImagesAndFinish(images)
+            }
+        } else {
+            registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { image ->
+                sendSelectedImagesAndFinish(listOfNotNull(image))
+            }
+        }
+        pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+    }
+
+    private fun sendSelectedImagesAndFinish(
+        images: List<Uri>
+    ) {
+        lifecycleScope.launch {
+            pickImageDataSource.emitImages(images)
+        }.invokeOnCompletion {
+            finish()
+        }
+    }
+
+    companion object {
+        const val MAXIMUM_SELECT_KEY = "meximum_select"
+    }
+}

--- a/data/src/main/java/com/weit2nd/data/source/pickimage/PickImageDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/pickimage/PickImageDataSource.kt
@@ -1,0 +1,48 @@
+package com.weit2nd.data.source.pickimage
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import com.weit2nd.data.util.ActivityProvider
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+
+class PickImageDataSource(
+    private val activityProvider: ActivityProvider,
+) {
+
+    private val selectImageEvent = MutableSharedFlow<List<Uri>>()
+
+    suspend fun pickImage(): Uri? {
+        startPickImage()
+        return selectImageEvent.first().firstOrNull()
+    }
+
+    suspend fun pickImages(
+        maximumSelect: Int,
+    ): List<Uri> {
+        startPickImage(maximumSelect)
+        return selectImageEvent.first()
+    }
+
+    suspend fun emitImages(
+        images: List<Uri>
+    ) {
+        selectImageEvent.emit(images)
+    }
+
+    private fun startPickImage(
+        maximumSelect: Int = 1,
+    ) {
+        val bundle = Bundle().apply {
+            putInt(PickImageActivity.MAXIMUM_SELECT_KEY, maximumSelect)
+        }
+        val intent = Intent(
+            activityProvider.currentActivity,
+            PickImageActivity::class.java,
+        ).apply {
+            putExtras(bundle)
+        }
+        activityProvider.currentActivity?.startActivity(intent)
+    }
+}

--- a/data/src/main/res/values/styles.xml
+++ b/data/src/main/res/values/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Transparent" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+</resources>

--- a/domain/src/main/java/com/weit2nd/domain/repository/pickimage/PickImageRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/pickimage/PickImageRepository.kt
@@ -1,0 +1,9 @@
+package com.weit2nd.domain.repository.pickimage
+
+interface PickImageRepository {
+    suspend fun pickImage(): String?
+
+    suspend fun pickImages(
+        maximumSelect: Int,
+    ): List<String>
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/pickimage/PickMultipleImagesUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/pickimage/PickMultipleImagesUseCase.kt
@@ -1,0 +1,21 @@
+package com.weit2nd.domain.usecase.pickimage
+
+import com.weit2nd.domain.repository.pickimage.PickImageRepository
+import javax.inject.Inject
+
+class PickMultipleImagesUseCase @Inject constructor(
+    private val repository: PickImageRepository,
+) {
+
+    /**
+     * 이미지 선택 화면을 띄워주고 선택한 이미지들을 반환합니다.
+     * @param maximumSelect 최대 선택 가능한 이미지 개수
+     */
+    suspend operator fun invoke(
+        maximumSelect: Int,
+    ): List<String> {
+        return repository.pickImages(
+            maximumSelect = maximumSelect,
+        )
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/pickimage/PickSingleImageUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/pickimage/PickSingleImageUseCase.kt
@@ -1,0 +1,17 @@
+package com.weit2nd.domain.usecase.pickimage
+
+import com.weit2nd.domain.repository.pickimage.PickImageRepository
+import javax.inject.Inject
+
+class PickSingleImageUseCase @Inject constructor(
+    private val repository: PickImageRepository,
+) {
+
+    /**
+     * 이미지 선택 화면을 띄워주고 선택한 이미지를 반환합니다.
+     * 선택한 이미지가 없으면 Null을 반환합니다.
+     */
+    suspend operator fun invoke(): String? {
+        return repository.pickImage()
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpIntent.kt
@@ -5,8 +5,7 @@ import android.net.Uri
 sealed class SignUpIntent {
 
     data object RequestSignUp : SignUpIntent()
-    data object ShowImagePicker : SignUpIntent()
-    data class SetProfileImage(val imageUri: Uri?) : SignUpIntent()
+    data object ChangeProfileImage : SignUpIntent()
     data class VerifyNickname(val nickname: String) : SignUpIntent()
     data class CheckNicknameDuplication(val nickname: String) : SignUpIntent()
     data class SetLoadingState(val isLoading: Boolean) : SignUpIntent()

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpScreen.kt
@@ -1,10 +1,5 @@
 package com.weit2nd.presentation.ui.signup
 
-import android.net.Uri
-import androidx.activity.compose.ManagedActivityResultLauncher
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -45,15 +40,10 @@ fun SignUpScreen(
     navToHome: (User) -> Unit,
 ) {
     val state = vm.collectAsState()
-    val storageAccessLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri: Uri? ->
-            vm.onProfileImageChoose(uri)
-        }
     vm.collectSideEffect { sideEffect ->
         handleSideEffects(
             sideEffect = sideEffect,
             navToHome = navToHome,
-            storageAccessLauncher = storageAccessLauncher,
         )
     }
 
@@ -99,17 +89,10 @@ fun SignUpScreen(
 private fun handleSideEffects(
     sideEffect: SignUpSideEffect,
     navToHome: (User) -> Unit,
-    storageAccessLauncher: ManagedActivityResultLauncher<PickVisualMediaRequest, Uri?>,
 ) {
     when (sideEffect) {
         is SignUpSideEffect.NavToHome -> {
             navToHome(sideEffect.user)
-        }
-
-        SignUpSideEffect.ShowImagePicker -> {
-            storageAccessLauncher.launch(
-                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-            )
         }
     }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpSideEffect.kt
@@ -3,10 +3,7 @@ package com.weit2nd.presentation.ui.signup
 import com.weit2nd.domain.model.User
 
 sealed class SignUpSideEffect {
-
     data class NavToHome(
         val user: User,
     ) : SignUpSideEffect()
-
-    data object ShowImagePicker : SignUpSideEffect()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
@@ -1,8 +1,9 @@
 package com.weit2nd.presentation.ui.signup
 
-import android.net.Uri
+import androidx.core.net.toUri
 import androidx.lifecycle.viewModelScope
 import com.weit2nd.domain.model.User
+import com.weit2nd.domain.usecase.pickimage.PickSingleImageUseCase
 import com.weit2nd.domain.usecase.signup.CheckNicknameDuplicateUseCase
 import com.weit2nd.domain.usecase.signup.VerifyNicknameUseCase
 import com.weit2nd.presentation.base.BaseViewModel
@@ -19,6 +20,7 @@ import javax.inject.Inject
 class SignUpViewModel @Inject constructor(
     private val verifyNicknameUseCase: VerifyNicknameUseCase,
     private val checkNicknameDuplicateUseCase: CheckNicknameDuplicateUseCase,
+    private val pickSingleImageUseCase: PickSingleImageUseCase,
 ) : BaseViewModel<SignUpState, SignUpSideEffect>() {
 
     override val container = container<SignUpState, SignUpSideEffect>(SignUpState())
@@ -29,11 +31,7 @@ class SignUpViewModel @Inject constructor(
     }
 
     fun onProfileImageClick() {
-        SignUpIntent.ShowImagePicker.post()
-    }
-
-    fun onProfileImageChoose(imageUri: Uri?) {
-        SignUpIntent.SetProfileImage(imageUri).post()
+        SignUpIntent.ChangeProfileImage.post()
     }
 
     fun onNicknameInputValueChange(nickname: String) {
@@ -63,15 +61,14 @@ class SignUpViewModel @Inject constructor(
                 }
             }
 
-            SignUpIntent.ShowImagePicker -> {
-                postSideEffect(SignUpSideEffect.ShowImagePicker)
-            }
-
-            is SignUpIntent.SetProfileImage -> {
-                reduce {
-                    state.copy(
-                        profileImageUri = imageUri
-                    )
+            SignUpIntent.ChangeProfileImage -> {
+                val result = pickSingleImageUseCase.invoke()
+                if (result != null) {
+                    reduce {
+                        state.copy(
+                            profileImageUri = result.toUri()
+                        )
+                    }
                 }
             }
 


### PR DESCRIPTION
### 개요
- Storage Access Framework 기능 Data 모듈로 분리

### 변경사항
- Presentation에서 하고 있던 SAF 동작을 Data로 옮겼습니다.

### 관련 지라 및 위키 링크
 - [ROFO-39](https://weit-2nd.atlassian.net/browse/ROFO-39) 

### 리뷰어에게 하고 싶은 말
- Data로 옮기면서 로직이 살짝 복잡해졌습니다.
  - DataSource에서 SAF를 올리기 위한 투명 액티비티를 올리고 거기서 사진 선택이 끝나면 DataSource로 이미지를 전달하는 구조
- 그래도 Presentation 단에서는 유즈케이스만 호출하면 매우 간단하게 사진 선택을 할 수 있기 때문에 의의가 있다고 봐용

[ROFO-39]: https://weit-2nd.atlassian.net/browse/ROFO-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ