### PR TITLE
ROFO-32 가게 위치 설정 화면 (간략 ver)

### DIFF
--- a/data/src/main/java/com/weit2nd/data/di/SearchLocationModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/SearchLocationModule.kt
@@ -1,0 +1,29 @@
+package com.weit2nd.data.di
+
+import com.weit2nd.data.repository.searchlocation.SearchLocationRepositoryImpl
+import com.weit2nd.data.source.searchlocation.SearchLocationDataSource
+import com.weit2nd.domain.repository.searchlocation.SearchLocationRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object SearchLocationModule {
+
+    @ViewModelScoped
+    @Provides
+    fun providesSearchLocationRepository(
+        searchLocationDataSource: SearchLocationDataSource,
+    ): SearchLocationRepository {
+        return SearchLocationRepositoryImpl(searchLocationDataSource)
+    }
+
+    @ViewModelScoped
+    @Provides
+    fun providesSearchLocationDatasource(): SearchLocationDataSource {
+        return SearchLocationDataSource()
+    }
+}

--- a/data/src/main/java/com/weit2nd/data/model/LocationDTO.kt
+++ b/data/src/main/java/com/weit2nd/data/model/LocationDTO.kt
@@ -2,7 +2,7 @@ package com.weit2nd.data.model
 
 data class LocationDTO(
     val name: String,
-    val locationDetail: String,
+    val address: String,
     val latitude: Double,
     val longitude: Double,
 )

--- a/data/src/main/java/com/weit2nd/data/model/LocationDTO.kt
+++ b/data/src/main/java/com/weit2nd/data/model/LocationDTO.kt
@@ -1,0 +1,8 @@
+package com.weit2nd.data.model
+
+data class LocationDTO(
+    val name: String,
+    val locationDetail: String,
+    val latitude: Double,
+    val longitude: Double,
+)

--- a/data/src/main/java/com/weit2nd/data/repository/searchlocation/SearchLocationRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/searchlocation/SearchLocationRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.weit2nd.data.repository.searchlocation
+
+import com.weit2nd.data.model.LocationDTO
+import com.weit2nd.data.source.searchlocation.SearchLocationDataSource
+import com.weit2nd.domain.model.Coordinate
+import com.weit2nd.domain.model.Location
+import com.weit2nd.domain.repository.searchlocation.SearchLocationRepository
+import javax.inject.Inject
+
+class SearchLocationRepositoryImpl @Inject constructor(
+    private val searchLocationDataSource: SearchLocationDataSource,
+) : SearchLocationRepository {
+
+    override suspend fun searchLocation(searchWord: String): List<Location> {
+        return searchLocationDataSource.getLocations(searchWord).map { it.toLocation() }
+    }
+
+    private fun LocationDTO.toLocation() = Location(
+        name = name,
+        locationDetail = locationDetail,
+        coordinate = Coordinate(latitude = latitude, longitude = longitude),
+    )
+}

--- a/data/src/main/java/com/weit2nd/data/repository/searchlocation/SearchLocationRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/searchlocation/SearchLocationRepositoryImpl.kt
@@ -21,7 +21,7 @@ class SearchLocationRepositoryImpl @Inject constructor(
 
     private fun LocationDTO.toLocation() = Location(
         name = name,
-        locationDetail = locationDetail,
+        address = address,
         coordinate = Coordinate(latitude = latitude, longitude = longitude),
     )
 }

--- a/data/src/main/java/com/weit2nd/data/repository/searchlocation/SearchLocationRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/searchlocation/SearchLocationRepositoryImpl.kt
@@ -11,8 +11,8 @@ class SearchLocationRepositoryImpl @Inject constructor(
     private val searchLocationDataSource: SearchLocationDataSource,
 ) : SearchLocationRepository {
 
-    override suspend fun searchLocation(searchWord: String): List<Location> {
-        return searchLocationDataSource.getLocations(searchWord).map { it.toLocation() }
+    override suspend fun searchLocationsWithWord(searchWord: String): List<Location> {
+        return searchLocationDataSource.getLocationsWithWord(searchWord).map { it.toLocation() }
     }
 
     override suspend fun searchLocationWithCoordinate(coordinate: Coordinate): Location {

--- a/data/src/main/java/com/weit2nd/data/repository/searchlocation/SearchLocationRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/searchlocation/SearchLocationRepositoryImpl.kt
@@ -15,6 +15,10 @@ class SearchLocationRepositoryImpl @Inject constructor(
         return searchLocationDataSource.getLocations(searchWord).map { it.toLocation() }
     }
 
+    override suspend fun searchLocationWithCoordinate(coordinate: Coordinate): Location {
+        return searchLocationDataSource.getLocationWithCoordinate(coordinate).toLocation()
+    }
+
     private fun LocationDTO.toLocation() = Location(
         name = name,
         locationDetail = locationDetail,

--- a/data/src/main/java/com/weit2nd/data/source/searchlocation/SearchLocationDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/searchlocation/SearchLocationDataSource.kt
@@ -11,7 +11,7 @@ class SearchLocationDataSource @Inject constructor() {
         return List(100) {
             LocationDTO(
                 name = "위치이름$it",
-                locationDetail = "서울 중구 세종대로",
+                address = "서울 중구 세종대로",
                 latitude = 0.0,
                 longitude = 0.0
             )
@@ -22,7 +22,7 @@ class SearchLocationDataSource @Inject constructor() {
         delay(1000)
         return LocationDTO(
             name = "위치이름",
-            locationDetail = "서울 중구 세종대로${coordinate.latitude}",
+            address = "서울 중구 세종대로${coordinate.latitude}",
             latitude = 0.0,
             longitude = 0.0
         )

--- a/data/src/main/java/com/weit2nd/data/source/searchlocation/SearchLocationDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/searchlocation/SearchLocationDataSource.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 
 class SearchLocationDataSource @Inject constructor() {
 
-    suspend fun getLocations(searchWord: String): List<LocationDTO> {
+    suspend fun getLocationsWithWord(searchWord: String): List<LocationDTO> {
         return List(100) {
             LocationDTO(
                 name = "위치이름$it",

--- a/data/src/main/java/com/weit2nd/data/source/searchlocation/SearchLocationDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/searchlocation/SearchLocationDataSource.kt
@@ -1,6 +1,8 @@
 package com.weit2nd.data.source.searchlocation
 
 import com.weit2nd.data.model.LocationDTO
+import com.weit2nd.domain.model.Coordinate
+import kotlinx.coroutines.delay
 import javax.inject.Inject
 
 class SearchLocationDataSource @Inject constructor() {
@@ -14,5 +16,15 @@ class SearchLocationDataSource @Inject constructor() {
                 longitude = 0.0
             )
         }
+    }
+
+    suspend fun getLocationWithCoordinate(coordinate: Coordinate): LocationDTO {
+        delay(1000)
+        return LocationDTO(
+            name = "위치이름",
+            locationDetail = "서울 중구 세종대로${coordinate.latitude}",
+            latitude = 0.0,
+            longitude = 0.0
+        )
     }
 }

--- a/data/src/main/java/com/weit2nd/data/source/searchlocation/SearchLocationDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/searchlocation/SearchLocationDataSource.kt
@@ -1,0 +1,18 @@
+package com.weit2nd.data.source.searchlocation
+
+import com.weit2nd.data.model.LocationDTO
+import javax.inject.Inject
+
+class SearchLocationDataSource @Inject constructor() {
+
+    suspend fun getLocations(searchWord: String): List<LocationDTO> {
+        return List(100) {
+            LocationDTO(
+                name = "위치이름$it",
+                locationDetail = "서울 중구 세종대로",
+                latitude = 0.0,
+                longitude = 0.0
+            )
+        }
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/model/Location.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/Location.kt
@@ -1,0 +1,7 @@
+package com.weit2nd.domain.model
+
+data class Location(
+    val name: String,
+    val locationDetail: String,
+    val coordinate: Coordinate,
+)

--- a/domain/src/main/java/com/weit2nd/domain/model/Location.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/Location.kt
@@ -2,6 +2,6 @@ package com.weit2nd.domain.model
 
 data class Location(
     val name: String,
-    val locationDetail: String,
+    val address: String,
     val coordinate: Coordinate,
 )

--- a/domain/src/main/java/com/weit2nd/domain/repository/searchlocation/SearchLocationRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/searchlocation/SearchLocationRepository.kt
@@ -1,0 +1,8 @@
+package com.weit2nd.domain.repository.searchlocation
+
+import com.weit2nd.domain.model.Location
+
+interface SearchLocationRepository {
+
+    suspend fun searchLocation(searchWord: String): List<Location>
+}

--- a/domain/src/main/java/com/weit2nd/domain/repository/searchlocation/SearchLocationRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/searchlocation/SearchLocationRepository.kt
@@ -5,6 +5,6 @@ import com.weit2nd.domain.model.Location
 
 interface SearchLocationRepository {
 
-    suspend fun searchLocation(searchWord: String): List<Location>
+    suspend fun searchLocationsWithWord(searchWord: String): List<Location>
     suspend fun searchLocationWithCoordinate(coordinate: Coordinate): Location
 }

--- a/domain/src/main/java/com/weit2nd/domain/repository/searchlocation/SearchLocationRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/searchlocation/SearchLocationRepository.kt
@@ -1,8 +1,10 @@
 package com.weit2nd.domain.repository.searchlocation
 
+import com.weit2nd.domain.model.Coordinate
 import com.weit2nd.domain.model.Location
 
 interface SearchLocationRepository {
 
     suspend fun searchLocation(searchWord: String): List<Location>
+    suspend fun searchLocationWithCoordinate(coordinate: Coordinate): Location
 }

--- a/domain/src/main/java/com/weit2nd/domain/usecase/selectloction/SearchLocationUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/selectloction/SearchLocationUseCase.kt
@@ -1,0 +1,14 @@
+package com.weit2nd.domain.usecase.selectloction
+
+import com.weit2nd.domain.model.Location
+import com.weit2nd.domain.repository.searchlocation.SearchLocationRepository
+import javax.inject.Inject
+
+class SearchLocationUseCase @Inject constructor(
+    val repository: SearchLocationRepository
+) {
+
+    suspend operator fun invoke(searchWord: String): List<Location> {
+        return repository.searchLocation(searchWord)
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/selectloction/SearchLocationWithCoordinateUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/selectloction/SearchLocationWithCoordinateUseCase.kt
@@ -1,0 +1,15 @@
+package com.weit2nd.domain.usecase.selectloction
+
+import com.weit2nd.domain.model.Coordinate
+import com.weit2nd.domain.model.Location
+import com.weit2nd.domain.repository.searchlocation.SearchLocationRepository
+import javax.inject.Inject
+
+class SearchLocationWithCoordinateUseCase @Inject constructor(
+    val repository: SearchLocationRepository
+) {
+
+    suspend operator fun invoke(coordinate: Coordinate): Location {
+        return repository.searchLocationWithCoordinate(coordinate)
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/selectloction/SearchLocationWithWordUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/selectloction/SearchLocationWithWordUseCase.kt
@@ -9,6 +9,6 @@ class SearchLocationWithWordUseCase @Inject constructor(
 ) {
 
     suspend operator fun invoke(searchWord: String): List<Location> {
-        return repository.searchLocation(searchWord)
+        return repository.searchLocationsWithWord(searchWord)
     }
 }

--- a/domain/src/main/java/com/weit2nd/domain/usecase/selectloction/SearchLocationWithWordUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/selectloction/SearchLocationWithWordUseCase.kt
@@ -4,7 +4,7 @@ import com.weit2nd.domain.model.Location
 import com.weit2nd.domain.repository.searchlocation.SearchLocationRepository
 import javax.inject.Inject
 
-class SearchLocationUseCase @Inject constructor(
+class SearchLocationWithWordUseCase @Inject constructor(
     val repository: SearchLocationRepository
 ) {
 

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -13,9 +13,12 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.google.gson.Gson
+import com.weit2nd.domain.model.Coordinate
 import com.weit2nd.domain.model.User
+import com.weit2nd.presentation.navigation.dto.toCoordinateDTO
 import com.weit2nd.presentation.navigation.type.UserType
 import com.weit2nd.presentation.navigation.dto.toUserDTO
+import com.weit2nd.presentation.navigation.type.CoordinateType
 import com.weit2nd.presentation.ui.home.HomeScreen
 import com.weit2nd.presentation.ui.login.LoginScreen
 import com.weit2nd.presentation.ui.select.location.SelectLocationScreen
@@ -109,7 +112,7 @@ private fun NavGraphBuilder.selectLocationComposable(
     composable(SelectLocationRoutes.GRAPH) {
         SelectLocationScreen(
             navToMap = {
-                navController.navigate(SelectLocationMapRoutes.GRAPH) {
+                navController.navigateToSelectLocationMap() {
                     popUpTo(SelectLocationMapRoutes.GRAPH) {
                         inclusive = true
                     }
@@ -122,7 +125,12 @@ private fun NavGraphBuilder.selectLocationComposable(
 private fun NavGraphBuilder.selectLocationMapComposable(
     navController: NavHostController,
 ) {
-    composable(SelectLocationMapRoutes.GRAPH) {
+    composable(
+        route = "${SelectLocationMapRoutes.GRAPH}/{${SelectLocationMapRoutes.INITIAL_POSITION_KEY}}",
+        arguments = listOf(navArgument(SelectLocationMapRoutes.INITIAL_POSITION_KEY) {
+            type = CoordinateType()
+        }),
+    ) {
         SelectLocationMapScreen()
     }
 }
@@ -133,6 +141,14 @@ private fun NavHostController.navigateToHome(
 ) {
     val userJson = Uri.encode(Gson().toJson(user.toUserDTO()))
     navigate("${HomeNavRoutes.GRAPH}/$userJson", builder)
+}
+
+private fun NavHostController.navigateToSelectLocationMap(
+    coordinate: Coordinate = Coordinate(37.56, 126.94),
+    builder: NavOptionsBuilder.() -> Unit = {},
+) {
+    val coordinateJson = Uri.encode(Gson().toJson(coordinate.toCoordinateDTO()))
+    navigate("${SelectLocationMapRoutes.GRAPH}/$coordinateJson", builder)
 }
 
 object LoginNavRoutes {
@@ -158,4 +174,5 @@ object SelectLocationRoutes {
 
 object SelectLocationMapRoutes {
     const val GRAPH = "select_location_map"
+    const val INITIAL_POSITION_KEY = "initial_position"
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -18,6 +18,8 @@ import com.weit2nd.presentation.navigation.type.UserType
 import com.weit2nd.presentation.navigation.dto.toUserDTO
 import com.weit2nd.presentation.ui.home.HomeScreen
 import com.weit2nd.presentation.ui.login.LoginScreen
+import com.weit2nd.presentation.ui.select.location.SelectLocationScreen
+import com.weit2nd.presentation.ui.select.location.map.SelectLocationMapScreen
 import com.weit2nd.presentation.ui.signup.SignUpScreen
 import com.weit2nd.presentation.ui.select.picture.SelectPictureScreen
 
@@ -38,6 +40,8 @@ fun AppNavHost(
         signUpComposable(navController)
         homeComposable(navController)
         selectPictureComposable(navController)
+        selectLocationComposable(navController)
+        selectLocationMapComposable(navController)
     }
 }
 
@@ -99,6 +103,30 @@ private fun NavGraphBuilder.selectPictureComposable(
     }
 }
 
+private fun NavGraphBuilder.selectLocationComposable(
+    navController: NavHostController,
+) {
+    composable(SelectLocationRoutes.GRAPH) {
+        SelectLocationScreen(
+            navToMap = {
+                navController.navigate(SelectLocationMapRoutes.GRAPH) {
+                    popUpTo(SelectLocationMapRoutes.GRAPH) {
+                        inclusive = true
+                    }
+                }
+            }
+        )
+    }
+}
+
+private fun NavGraphBuilder.selectLocationMapComposable(
+    navController: NavHostController,
+) {
+    composable(SelectLocationMapRoutes.GRAPH) {
+        SelectLocationMapScreen()
+    }
+}
+
 private fun NavHostController.navigateToHome(
     user: User,
     builder: NavOptionsBuilder.() -> Unit = {},
@@ -122,4 +150,12 @@ object HomeNavRoutes {
 
 object SelectPictureRoutes {
     const val GRAPH = "select_picture"
+}
+
+object SelectLocationRoutes {
+    const val GRAPH = "select_location"
+}
+
+object SelectLocationMapRoutes {
+    const val GRAPH = "select_location_map"
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/CoordinateDTO.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/CoordinateDTO.kt
@@ -1,0 +1,19 @@
+package com.weit2nd.presentation.navigation.dto
+
+import android.os.Parcelable
+import com.weit2nd.domain.model.Coordinate
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class CoordinateDTO(
+    val latitude: Double,
+    val longitude: Double,
+) : Parcelable
+
+fun CoordinateDTO.toCoordinate(): Coordinate = Coordinate(
+    latitude = latitude, longitude = longitude,
+)
+
+fun Coordinate.toCoordinateDTO(): CoordinateDTO = CoordinateDTO(
+    latitude = latitude, longitude = longitude,
+)

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/type/CoordinateType.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/type/CoordinateType.kt
@@ -1,0 +1,25 @@
+package com.weit2nd.presentation.navigation.type
+
+import android.os.Build
+import android.os.Bundle
+import androidx.navigation.NavType
+import com.google.gson.Gson
+import com.weit2nd.presentation.navigation.dto.CoordinateDTO
+
+class CoordinateType : NavType<CoordinateDTO>(isNullableAllowed = false) {
+    override fun get(bundle: Bundle, key: String): CoordinateDTO? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            bundle.getParcelable(key, CoordinateDTO::class.java)
+        } else {
+            bundle.getParcelable(key)
+        }
+    }
+
+    override fun parseValue(value: String): CoordinateDTO {
+        return Gson().fromJson(value, CoordinateDTO::class.java)
+    }
+
+    override fun put(bundle: Bundle, key: String, value: CoordinateDTO) {
+        bundle.putParcelable(key, value)
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationIntent.kt
@@ -1,4 +1,6 @@
 package com.weit2nd.presentation.ui.select.location
 
 sealed class SelectLocationIntent {
+
+    data class SearchLocation(val input: String) : SelectLocationIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationIntent.kt
@@ -2,5 +2,6 @@ package com.weit2nd.presentation.ui.select.location
 
 sealed class SelectLocationIntent {
 
-    data class SearchLocation(val input: String) : SelectLocationIntent()
+    data object SearchLocation : SelectLocationIntent()
+    data class StoreSearchWord(val input: String) : SelectLocationIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationIntent.kt
@@ -1,0 +1,4 @@
+package com.weit2nd.presentation.ui.select.location
+
+sealed class SelectLocationIntent {
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
@@ -6,25 +6,34 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import org.orbitmvi.orbit.compose.collectAsState
 
 @Preview
 @Composable
-fun SelectLocationScreen() {
-
-    val itemsList = List(100) { "Item #$it" }
+fun SelectLocationScreen(
+    vm: SelectLocationViewModel = hiltViewModel()
+) {
+    val state = vm.collectAsState()
 
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -38,14 +47,11 @@ fun SelectLocationScreen() {
                 color = Color.Black
             ),
         )
-        TextField(
+        LocationTextField(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
-            value = "",
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-            placeholder = { "지번, 도로명, 건물명으로 검색" },
-            onValueChange = {},
+            onSearch = vm::onLocationSearch
         )
         Button(
             modifier = Modifier
@@ -58,14 +64,42 @@ fun SelectLocationScreen() {
         LazyColumn(
             modifier = Modifier.fillMaxWidth()
         ) {
-            items(itemsList) { item ->
+            items(state.value.searchResults) { item ->
                 Text(
-                    text = item,
+                    text = item.name,
                     fontSize = 20.sp,
-                    modifier = Modifier.padding(16.dp)
+                )
+                Text(
+                    text = item.locationDetail,
+                    fontSize = 16.sp,
+                    modifier = Modifier.padding(top = 4.dp, bottom = 12.dp)
                 )
             }
         }
     }
+}
+
+@Composable
+private fun LocationTextField(
+    modifier: Modifier,
+    onSearch: (String) -> Unit,
+) {
+    var userInput by remember { mutableStateOf(TextFieldValue()) }
+    TextField(
+        modifier = modifier,
+        value = userInput,
+        keyboardOptions = KeyboardOptions.Default.copy(
+            imeAction = ImeAction.Search
+        ),
+        placeholder = { "지번, 도로명, 건물명으로 검색" },
+        onValueChange = { newValue ->
+            userInput = newValue
+        },
+        keyboardActions = KeyboardActions(
+            onSearch = {
+                onSearch(userInput.text)
+            }
+        ),
+    )
 }
 

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
@@ -28,10 +28,10 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import org.orbitmvi.orbit.compose.collectAsState
 
-@Preview
 @Composable
 fun SelectLocationScreen(
-    vm: SelectLocationViewModel = hiltViewModel()
+    vm: SelectLocationViewModel = hiltViewModel(),
+    navToMap: () -> Unit,
 ) {
     val state = vm.collectAsState()
 
@@ -57,7 +57,7 @@ fun SelectLocationScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 16.dp, end = 16.dp),
-            onClick = { }
+            onClick = { navToMap() }
         ) {
             Text(text = "지도에서 찾기")
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
@@ -51,6 +51,7 @@ fun SelectLocationScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
+            onValueChange = vm::onValueChange,
             onSearch = vm::onLocationSearch
         )
         Button(
@@ -74,7 +75,8 @@ fun SelectLocationScreen(
 @Composable
 private fun LocationTextField(
     modifier: Modifier,
-    onSearch: (String) -> Unit,
+    onValueChange: (String) -> Unit,
+    onSearch: () -> Unit,
 ) {
     var userInput by remember { mutableStateOf(TextFieldValue()) }
     TextField(
@@ -86,11 +88,10 @@ private fun LocationTextField(
         placeholder = { Text(text = "지번, 도로명, 건물명으로 검색") },
         onValueChange = { newValue ->
             userInput = newValue
+            onValueChange(newValue.text)
         },
         keyboardActions = KeyboardActions(
-            onSearch = {
-                onSearch(userInput.text)
-            }
+            onSearch = { onSearch() }
         ),
     )
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
@@ -93,7 +93,7 @@ private fun LocationTextField(
         keyboardOptions = KeyboardOptions.Default.copy(
             imeAction = ImeAction.Search
         ),
-        placeholder = { "지번, 도로명, 건물명으로 검색" },
+        placeholder = { Text(text = "지번, 도로명, 건물명으로 검색") },
         onValueChange = { newValue ->
             userInput = newValue
         },

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -71,7 +70,7 @@ fun SelectLocationScreen(
                         fontSize = 20.sp,
                     )
                     Text(
-                        text = item.locationDetail,
+                        text = item.address,
                         fontSize = 16.sp,
                         modifier = Modifier.padding(top = 4.dp, bottom = 12.dp)
                     )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.weit2nd.domain.model.Location
 import org.orbitmvi.orbit.compose.collectAsState
 
 @Composable
@@ -64,17 +65,7 @@ fun SelectLocationScreen(
             modifier = Modifier.fillMaxWidth()
         ) {
             items(state.value.searchResults) { item ->
-                Column {
-                    Text(
-                        text = item.name,
-                        fontSize = 20.sp,
-                    )
-                    Text(
-                        text = item.address,
-                        fontSize = 16.sp,
-                        modifier = Modifier.padding(top = 4.dp, bottom = 12.dp)
-                    )
-                }
+                SearchLocationItem(item)
             }
         }
     }
@@ -102,5 +93,20 @@ private fun LocationTextField(
             }
         ),
     )
+}
+
+@Composable
+private fun SearchLocationItem(location: Location) {
+    Column {
+        Text(
+            text = location.name,
+            fontSize = 20.sp,
+        )
+        Text(
+            text = location.address,
+            fontSize = 16.sp,
+            modifier = Modifier.padding(top = 4.dp, bottom = 12.dp)
+        )
+    }
 }
 

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
@@ -65,15 +65,17 @@ fun SelectLocationScreen(
             modifier = Modifier.fillMaxWidth()
         ) {
             items(state.value.searchResults) { item ->
-                Text(
-                    text = item.name,
-                    fontSize = 20.sp,
-                )
-                Text(
-                    text = item.locationDetail,
-                    fontSize = 16.sp,
-                    modifier = Modifier.padding(top = 4.dp, bottom = 12.dp)
-                )
+                Column {
+                    Text(
+                        text = item.name,
+                        fontSize = 20.sp,
+                    )
+                    Text(
+                        text = item.locationDetail,
+                        fontSize = 16.sp,
+                        modifier = Modifier.padding(top = 4.dp, bottom = 12.dp)
+                    )
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationScreen.kt
@@ -1,0 +1,71 @@
+package com.weit2nd.presentation.ui.select.location
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Preview
+@Composable
+fun SelectLocationScreen() {
+
+    val itemsList = List(100) { "Item #$it" }
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Text(
+            modifier = Modifier.padding(16.dp),
+            text = "가게 위치를 설정해주세요",
+            style = TextStyle(
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.Black
+            ),
+        )
+        TextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            value = "",
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+            placeholder = { "지번, 도로명, 건물명으로 검색" },
+            onValueChange = {},
+        )
+        Button(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 16.dp),
+            onClick = { }
+        ) {
+            Text(text = "지도에서 찾기")
+        }
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            items(itemsList) { item ->
+                Text(
+                    text = item,
+                    fontSize = 20.sp,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+        }
+    }
+}
+

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationSideEffect.kt
@@ -1,0 +1,4 @@
+package com.weit2nd.presentation.ui.select.location
+
+sealed class SelectLocationSideEffect {
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationState.kt
@@ -4,4 +4,5 @@ import com.weit2nd.domain.model.Location
 
 data class SelectLocationState(
     val searchResults: List<Location> = emptyList(),
+    val userInput: String = "",
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationState.kt
@@ -1,3 +1,7 @@
 package com.weit2nd.presentation.ui.select.location
 
-class SelectLocationState()
+import com.weit2nd.domain.model.Location
+
+data class SelectLocationState(
+    val searchResults: List<Location> = emptyList(),
+)

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationState.kt
@@ -1,0 +1,3 @@
+package com.weit2nd.presentation.ui.select.location
+
+class SelectLocationState()

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationViewModel.kt
@@ -16,15 +16,28 @@ class SelectLocationViewModel @Inject constructor(
     override val container =
         container<SelectLocationState, SelectLocationSideEffect>(SelectLocationState())
 
-    fun onLocationSearch(input: String) {
-        SelectLocationIntent.SearchLocation(input).post()
+    fun onValueChange(input: String) {
+        SelectLocationIntent.StoreSearchWord(input).post()
+    }
+
+    fun onLocationSearch() {
+        SelectLocationIntent.SearchLocation.post()
     }
 
     private fun SelectLocationIntent.post() = intent {
         when (this@post) {
-            is SelectLocationIntent.SearchLocation -> {
+            is SelectLocationIntent.StoreSearchWord -> {
+                reduce {
+                    state.copy(
+                        userInput = input,
+                    )
+                }
+            }
+
+            SelectLocationIntent.SearchLocation -> {
                 runCatching {
-                    val result = searchLocationWithWordUseCase.invoke(input)
+                    val result =
+                        searchLocationWithWordUseCase.invoke(container.stateFlow.value.userInput)
                     reduce {
                         state.copy(
                             searchResults = result

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationViewModel.kt
@@ -1,13 +1,37 @@
 package com.weit2nd.presentation.ui.select.location
 
+import com.weit2nd.domain.usecase.selectloction.SearchLocationUseCase
 import com.weit2nd.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
 @HiltViewModel
-class SelectLocationViewModel @Inject constructor() :
+class SelectLocationViewModel @Inject constructor(
+    private val searchLocationUseCase: SearchLocationUseCase
+) :
     BaseViewModel<SelectLocationState, SelectLocationSideEffect>() {
     override val container =
         container<SelectLocationState, SelectLocationSideEffect>(SelectLocationState())
+
+    fun onLocationSearch(input: String) {
+        SelectLocationIntent.SearchLocation(input).post()
+    }
+
+    private fun SelectLocationIntent.post() = intent {
+        when (this@post) {
+            is SelectLocationIntent.SearchLocation -> {
+                runCatching {
+                    val result = searchLocationUseCase.invoke(input)
+                    reduce {
+                        state.copy(
+                            searchResults = result
+                        )
+                    }
+                }
+            }
+        }
+    }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationViewModel.kt
@@ -1,0 +1,13 @@
+package com.weit2nd.presentation.ui.select.location
+
+import com.weit2nd.presentation.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.orbitmvi.orbit.viewmodel.container
+import javax.inject.Inject
+
+@HiltViewModel
+class SelectLocationViewModel @Inject constructor() :
+    BaseViewModel<SelectLocationState, SelectLocationSideEffect>() {
+    override val container =
+        container<SelectLocationState, SelectLocationSideEffect>(SelectLocationState())
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/SelectLocationViewModel.kt
@@ -1,6 +1,6 @@
 package com.weit2nd.presentation.ui.select.location
 
-import com.weit2nd.domain.usecase.selectloction.SearchLocationUseCase
+import com.weit2nd.domain.usecase.selectloction.SearchLocationWithWordUseCase
 import com.weit2nd.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -10,7 +10,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SelectLocationViewModel @Inject constructor(
-    private val searchLocationUseCase: SearchLocationUseCase
+    private val searchLocationWithWordUseCase: SearchLocationWithWordUseCase
 ) :
     BaseViewModel<SelectLocationState, SelectLocationSideEffect>() {
     override val container =
@@ -24,7 +24,7 @@ class SelectLocationViewModel @Inject constructor(
         when (this@post) {
             is SelectLocationIntent.SearchLocation -> {
                 runCatching {
-                    val result = searchLocationUseCase.invoke(input)
+                    val result = searchLocationWithWordUseCase.invoke(input)
                     reduce {
                         state.copy(
                             searchResults = result

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapIntent.kt
@@ -8,7 +8,7 @@ sealed class SelectLocationMapIntent {
 
     data class StoreMap(val map: KakaoMap) : SelectLocationMapIntent()
 
-    data class StoreMapCenterOffset(val offset: IntOffset) : SelectLocationMapIntent()
+    data class StoreSelectMarkerOffset(val offset: IntOffset) : SelectLocationMapIntent()
 
     data class SearchLocation(val coordinate: LatLng?) : SelectLocationMapIntent()
 

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapIntent.kt
@@ -1,11 +1,14 @@
 package com.weit2nd.presentation.ui.select.location.map
 
+import androidx.compose.ui.unit.IntOffset
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.LatLng
 
 sealed class SelectLocationMapIntent {
 
     data class StoreMap(val map: KakaoMap) : SelectLocationMapIntent()
+
+    data class StoreMapCenterOffset(val offset: IntOffset) : SelectLocationMapIntent()
 
     data class SearchLocation(val coordinate: LatLng?) : SelectLocationMapIntent()
 

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapIntent.kt
@@ -7,10 +7,8 @@ import com.kakao.vectormap.LatLng
 sealed class SelectLocationMapIntent {
 
     data class StoreMap(val map: KakaoMap) : SelectLocationMapIntent()
-
     data class StoreSelectMarkerOffset(val offset: IntOffset) : SelectLocationMapIntent()
-
+    data object StartLocatingMap : SelectLocationMapIntent()
     data class SearchLocation(val coordinate: LatLng?) : SelectLocationMapIntent()
-
     data class RequestCameraMove(val position: LatLng) : SelectLocationMapIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapIntent.kt
@@ -1,0 +1,13 @@
+package com.weit2nd.presentation.ui.select.location.map
+
+import com.kakao.vectormap.KakaoMap
+import com.kakao.vectormap.LatLng
+
+sealed class SelectLocationMapIntent {
+
+    data class StoreMap(val map: KakaoMap) : SelectLocationMapIntent()
+
+    data class SearchLocation(val coordinate: LatLng?) : SelectLocationMapIntent()
+
+    data class RequestCameraMove(val position: LatLng) : SelectLocationMapIntent()
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
@@ -1,0 +1,188 @@
+package com.weit2nd.presentation.ui.select.location.map
+
+import android.R
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import com.kakao.vectormap.KakaoMap
+import com.kakao.vectormap.KakaoMapReadyCallback
+import com.kakao.vectormap.LatLng
+import com.kakao.vectormap.MapLifeCycleCallback
+import com.kakao.vectormap.MapView
+import com.kakao.vectormap.camera.CameraUpdateFactory
+import com.kakao.vectormap.label.LabelOptions
+import com.kakao.vectormap.label.LabelStyle
+import com.kakao.vectormap.label.LabelStyles
+import com.weit2nd.presentation.ui.common.currentposition.CurrentPositionBtn
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
+
+@Composable
+fun SelectLocationMapScreen(
+    vm: SelectLocationMapViewModel = hiltViewModel(),
+    position: LatLng = LatLng.from(37.5597706, 126.9423666),
+) {
+    val state = vm.collectAsState()
+    vm.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is SelectLocationMapSideEffect.MoveCamera -> {
+                val cameraUpdate = CameraUpdateFactory.newCenterPosition(sideEffect.position)
+                sideEffect.map.moveCamera(cameraUpdate)
+            }
+        }
+    }
+    val context = LocalContext.current
+    val mapView = remember {
+        MapView(context).apply {
+            start(
+                mapLifeCycleCallback(),
+                kakaoMapReadyCallback(
+                    vm::onMapReady,
+                    vm::onCameraMoveEnd,
+                    position,
+                ),
+            )
+        }
+    }
+
+    DisposableEffectWithLifeCycle(onResume = mapView::resume, onPause = mapView::pause)
+
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Box(modifier = Modifier.weight(3f)) {
+            AndroidView(
+                modifier = Modifier,
+                factory = { mapView }
+            )
+
+            CurrentPositionBtn(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(end = 16.dp, bottom = 24.dp),
+                onClick = vm::onClickCurrentPositionBtn
+            )
+        }
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = state.value.location.locationDetail,
+                style = TextStyle(
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.Black
+                ),
+            )
+            Button(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                onClick = { }
+            ) {
+                Text(text = "이 위치로 등록")
+            }
+        }
+
+    }
+}
+
+private fun mapLifeCycleCallback() = object : MapLifeCycleCallback() {
+    override fun onMapDestroy() {
+        Log.d("KakaoMap", "onMapDestroy")
+    }
+
+    override fun onMapError(error: Exception) {
+        Log.e("KakaoMap", "onMapError: ", error)
+    }
+}
+
+private fun kakaoMapReadyCallback(
+    onMapReady: (KakaoMap) -> Unit,
+    onCameraMoveEnd: (LatLng?) -> Unit,
+    position: LatLng,
+) = object : KakaoMapReadyCallback() {
+    override fun onMapReady(map: KakaoMap) {
+        onMapReady(map)
+        onCameraMoveEnd(map, onCameraMoveEnd)
+        map.setOnCameraMoveEndListener { kakaoMap, _, _ ->
+            onCameraMoveEnd(kakaoMap, onCameraMoveEnd)
+        }
+    }
+
+    override fun getPosition(): LatLng = position
+}
+
+private fun onCameraMoveEnd(
+    map: KakaoMap,
+    onCameraMoveEnd: (LatLng?) -> Unit,
+) {
+    val viewport = map.viewport
+
+    val x = viewport.width() / 2
+    val y = viewport.height() / 2
+    val position = map.fromScreenPoint(x, y)
+    onCameraMoveEnd(position)
+
+    map.labelManager?.layer?.removeAll()
+    val styles = map.labelManager
+        ?.addLabelStyles(LabelStyles.from(LabelStyle.from(R.drawable.ic_menu_mylocation)))
+    val options = LabelOptions.from(position).setStyles(styles)
+    map.labelManager?.layer?.addLabel(options)
+
+}
+
+@Composable
+private fun DisposableEffectWithLifeCycle(
+    // 오류로 compose.ui의 LocalLifecycleOwner 사용
+    lifecycleOwner: LifecycleOwner = androidx.compose.ui.platform.LocalLifecycleOwner.current,
+    onResume: () -> Unit,
+    onPause: () -> Unit
+) {
+    val currentOnResume by rememberUpdatedState(onResume)
+    val currentOnPause by rememberUpdatedState(onPause)
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                currentOnResume()
+            } else if (event == Lifecycle.Event.ON_PAUSE) {
+                currentOnPause()
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+}
+

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
@@ -156,7 +156,7 @@ private fun BottomInfo(
     ) {
         Text(
             modifier = Modifier.fillMaxWidth(),
-            text = location.locationDetail,
+            text = location.address,
             style = TextStyle(
                 fontSize = 24.sp,
                 fontWeight = FontWeight.Bold,

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
@@ -98,9 +98,14 @@ fun SelectLocationMapScreen(
             )
 
             PositionSelectMarker(
-                mapRectSize,
-                onGloballyPositioned = vm::onGloballyPositioned,
-                selectMarkerOffset = state.value.selectMarkerOffset
+                modifier = Modifier
+                    .onGloballyPositioned { layoutCoordinates ->
+                        val imageSize = layoutCoordinates.size
+                        val centerX = mapRectSize.width / 2 - imageSize.width / 2
+                        val centerY = mapRectSize.height / 2 - imageSize.height / 2
+                        vm.onGloballyPositioned(IntOffset(centerX, centerY))
+                    }
+                    .offset { state.value.selectMarkerOffset },
             )
         }
         BottomInfo(
@@ -125,21 +130,12 @@ private fun handleSideEffects(sideEffect: SelectLocationMapSideEffect) {
 
 @Composable
 private fun PositionSelectMarker(
-    mapRectSize: IntSize,
-    onGloballyPositioned: (IntOffset) -> Unit,
-    selectMarkerOffset: IntOffset,
+    modifier: Modifier = Modifier,
 ) {
     Image(
+        modifier = modifier,
         painter = painterResource(R.drawable.ic_menu_mylocation),
-        contentDescription = "positionSelectMarker",
-        modifier = Modifier
-            .onGloballyPositioned { layoutCoordinates ->
-                val imageSize = layoutCoordinates.size
-                val centerX = mapRectSize.width / 2 - imageSize.width / 2
-                val centerY = mapRectSize.height / 2 - imageSize.height / 2
-                onGloballyPositioned(IntOffset(centerX, centerY))
-            }
-            .offset { selectMarkerOffset }
+        contentDescription = "positionSelectMarker"
     )
 }
 

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
@@ -67,7 +67,8 @@ fun SelectLocationMapScreen(
                 mapLifeCycleCallback(),
                 kakaoMapReadyCallback(
                     vm::onMapReady,
-                    vm::onCameraMoveEnd,
+                    onCameraMoveStart = vm::onCameraMoveStart,
+                    onCameraMoveEnd = vm::onCameraMoveEnd,
                     selectMarkerOffset = state.value.selectMarkerOffset,
                     position = position,
                 ),
@@ -132,7 +133,8 @@ fun SelectLocationMapScreen(
             Button(
                 modifier = Modifier
                     .fillMaxWidth(),
-                onClick = { }
+                onClick = { },
+                enabled = state.value.isLoading.not(),
             ) {
                 Text(text = "이 위치로 등록")
             }
@@ -153,6 +155,7 @@ private fun mapLifeCycleCallback() = object : MapLifeCycleCallback() {
 
 private fun kakaoMapReadyCallback(
     onMapReady: (KakaoMap) -> Unit,
+    onCameraMoveStart: () -> Unit,
     onCameraMoveEnd: (LatLng?) -> Unit,
     selectMarkerOffset: IntOffset,
     position: LatLng,
@@ -160,6 +163,9 @@ private fun kakaoMapReadyCallback(
     override fun onMapReady(map: KakaoMap) {
         onMapReady(map)
         onCameraMoveEnd(map, onCameraMoveEnd, selectMarkerOffset)
+        map.setOnCameraMoveStartListener { _, _ ->
+            onCameraMoveStart()
+        }
         map.setOnCameraMoveEndListener { kakaoMap, _, _ ->
             onCameraMoveEnd(kakaoMap, onCameraMoveEnd, selectMarkerOffset)
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
@@ -114,6 +114,7 @@ fun SelectLocationMapScreen(
                 .padding(16.dp),
             isLoading = state.value.isLoading,
             location = state.value.location,
+            onClick = {},
         )
     }
 }
@@ -143,6 +144,7 @@ private fun LocationInfoView(
     modifier: Modifier = Modifier,
     isLoading: Boolean,
     location: Location,
+    onClick: () -> Unit,
 ) {
     Column(
         modifier = modifier,
@@ -159,7 +161,7 @@ private fun LocationInfoView(
         )
         Button(
             modifier = Modifier.fillMaxWidth(),
-            onClick = { },
+            onClick = { onClick() },
             enabled = isLoading.not(),
         ) {
             Text(text = "이 위치로 등록")

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
@@ -108,14 +108,13 @@ fun SelectLocationMapScreen(
                     .offset { state.value.selectMarkerOffset },
             )
         }
-        BottomInfo(
+        LocationInfoView(
             modifier = Modifier
                 .weight(1f)
                 .padding(16.dp),
             isLoading = state.value.isLoading,
             location = state.value.location,
         )
-
     }
 }
 
@@ -140,7 +139,7 @@ private fun PositionSelectMarker(
 }
 
 @Composable
-private fun BottomInfo(
+private fun LocationInfoView(
     modifier: Modifier = Modifier,
     isLoading: Boolean,
     location: Location,

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapScreen.kt
@@ -50,7 +50,6 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 @Composable
 fun SelectLocationMapScreen(
     vm: SelectLocationMapViewModel = hiltViewModel(),
-    position: LatLng = LatLng.from(37.5597706, 126.9423666),
 ) {
     val state = vm.collectAsState()
     vm.collectSideEffect { sideEffect ->
@@ -66,7 +65,7 @@ fun SelectLocationMapScreen(
                     onCameraMoveStart = vm::onCameraMoveStart,
                     onCameraMoveEnd = vm::onCameraMoveEnd,
                     selectMarkerOffset = state.value.selectMarkerOffset,
-                    position = position,
+                    position = state.value.initialPosition.run { LatLng.from(latitude, longitude) },
                 ),
             )
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapSideEffect.kt
@@ -1,0 +1,9 @@
+package com.weit2nd.presentation.ui.select.location.map
+
+import com.kakao.vectormap.KakaoMap
+import com.kakao.vectormap.LatLng
+
+sealed class SelectLocationMapSideEffect {
+
+    data class MoveCamera(val map: KakaoMap, val position: LatLng) : SelectLocationMapSideEffect()
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapState.kt
@@ -1,0 +1,10 @@
+package com.weit2nd.presentation.ui.select.location.map
+
+import com.kakao.vectormap.KakaoMap
+import com.weit2nd.domain.model.Coordinate
+import com.weit2nd.domain.model.Location
+
+data class SelectLocationMapState(
+    val map: KakaoMap? = null,
+    val location: Location = Location("", "", Coordinate(0.0, 0.0)),
+)

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapState.kt
@@ -10,4 +10,5 @@ data class SelectLocationMapState(
     val selectMarkerOffset: IntOffset = IntOffset.Zero,
     val location: Location = Location("", "", Coordinate(0.0, 0.0)),
     val isLoading: Boolean = false,
+    val initialPosition: Coordinate = Coordinate(37.5597706, 126.9423666),
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapState.kt
@@ -9,4 +9,5 @@ data class SelectLocationMapState(
     val map: KakaoMap? = null,
     val selectMarkerOffset: IntOffset = IntOffset.Zero,
     val location: Location = Location("", "", Coordinate(0.0, 0.0)),
+    val isLoading: Boolean = false,
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapState.kt
@@ -1,10 +1,12 @@
 package com.weit2nd.presentation.ui.select.location.map
 
+import androidx.compose.ui.unit.IntOffset
 import com.kakao.vectormap.KakaoMap
 import com.weit2nd.domain.model.Coordinate
 import com.weit2nd.domain.model.Location
 
 data class SelectLocationMapState(
     val map: KakaoMap? = null,
+    val selectMarkerOffset: IntOffset = IntOffset.Zero,
     val location: Location = Location("", "", Coordinate(0.0, 0.0)),
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapViewModel.kt
@@ -1,5 +1,6 @@
 package com.weit2nd.presentation.ui.select.location.map
 
+import androidx.compose.ui.unit.IntOffset
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.LatLng
 import com.weit2nd.domain.model.Coordinate
@@ -23,6 +24,10 @@ class SelectLocationMapViewModel @Inject constructor(
         SelectLocationMapIntent.StoreMap(map).post()
     }
 
+    fun onGloballyPositioned(offset: IntOffset) {
+        SelectLocationMapIntent.StoreMapCenterOffset(offset).post()
+    }
+
     fun onCameraMoveEnd(coordinate: LatLng?) {
         SelectLocationMapIntent.SearchLocation(coordinate).post()
     }
@@ -37,6 +42,14 @@ class SelectLocationMapViewModel @Inject constructor(
                 reduce {
                     state.copy(
                         map = map
+                    )
+                }
+            }
+
+            is SelectLocationMapIntent.StoreMapCenterOffset -> {
+                reduce {
+                    state.copy(
+                        selectMarkerOffset = offset,
                     )
                 }
             }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapViewModel.kt
@@ -1,12 +1,16 @@
 package com.weit2nd.presentation.ui.select.location.map
 
 import androidx.compose.ui.unit.IntOffset
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.LatLng
 import com.weit2nd.domain.model.Coordinate
 import com.weit2nd.domain.usecase.selectloction.SearchLocationWithCoordinateUseCase
 import com.weit2nd.presentation.base.BaseViewModel
+import com.weit2nd.presentation.navigation.SelectLocationMapRoutes
+import com.weit2nd.presentation.navigation.dto.CoordinateDTO
+import com.weit2nd.presentation.navigation.dto.toCoordinate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -18,10 +22,19 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SelectLocationMapViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val searchLocationWithCoordinateUseCase: SearchLocationWithCoordinateUseCase,
 ) : BaseViewModel<SelectLocationMapState, SelectLocationMapSideEffect>() {
     override val container =
-        container<SelectLocationMapState, SelectLocationMapSideEffect>(SelectLocationMapState())
+        container<SelectLocationMapState, SelectLocationMapSideEffect>(
+            SelectLocationMapState(
+                initialPosition = checkNotNull(
+                    savedStateHandle.get<CoordinateDTO>(
+                        SelectLocationMapRoutes.INITIAL_POSITION_KEY
+                    )?.toCoordinate()
+                )
+            )
+        )
     private var searchLocationJob: Job = Job().apply { complete() }
 
     fun onMapReady(map: KakaoMap) {

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapViewModel.kt
@@ -85,27 +85,26 @@ class SelectLocationMapViewModel @Inject constructor(
             }
 
             is SelectLocationMapIntent.SearchLocation -> {
-                if (coordinate != null) {
-                    searchLocationJob = viewModelScope.launch {
-                        val location = searchLocationWithCoordinateUseCase.invoke(
-                            Coordinate(
-                                latitude = coordinate.latitude,
-                                longitude = coordinate.longitude
-                            )
+                if (coordinate == null) return@intent
+                searchLocationJob = viewModelScope.launch {
+                    val location = searchLocationWithCoordinateUseCase.invoke(
+                        Coordinate(
+                            latitude = coordinate.latitude,
+                            longitude = coordinate.longitude
                         )
-                        reduce {
-                            state.copy(
-                                location = location
-                            )
-                        }
-                    }.apply {
-                        invokeOnCompletion {
-                            intent {
-                                reduce {
-                                    state.copy(
-                                        isLoading = false,
-                                    )
-                                }
+                    )
+                    reduce {
+                        state.copy(
+                            location = location
+                        )
+                    }
+                }.apply {
+                    invokeOnCompletion {
+                        intent {
+                            reduce {
+                                state.copy(
+                                    isLoading = false,
+                                )
                             }
                         }
                     }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapViewModel.kt
@@ -1,0 +1,67 @@
+package com.weit2nd.presentation.ui.select.location.map
+
+import com.kakao.vectormap.KakaoMap
+import com.kakao.vectormap.LatLng
+import com.weit2nd.domain.model.Coordinate
+import com.weit2nd.domain.usecase.selectloction.SearchLocationWithCoordinateUseCase
+import com.weit2nd.presentation.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+import javax.inject.Inject
+
+@HiltViewModel
+class SelectLocationMapViewModel @Inject constructor(
+    private val searchLocationWithCoordinateUseCase: SearchLocationWithCoordinateUseCase,
+) : BaseViewModel<SelectLocationMapState, SelectLocationMapSideEffect>() {
+    override val container =
+        container<SelectLocationMapState, SelectLocationMapSideEffect>(SelectLocationMapState())
+
+    fun onMapReady(map: KakaoMap) {
+        SelectLocationMapIntent.StoreMap(map).post()
+    }
+
+    fun onCameraMoveEnd(coordinate: LatLng?) {
+        SelectLocationMapIntent.SearchLocation(coordinate).post()
+    }
+
+    fun onClickCurrentPositionBtn(currentPosition: LatLng) {
+        SelectLocationMapIntent.RequestCameraMove(currentPosition).post()
+    }
+
+    private fun SelectLocationMapIntent.post() = intent {
+        when (this@post) {
+            is SelectLocationMapIntent.StoreMap -> {
+                reduce {
+                    state.copy(
+                        map = map
+                    )
+                }
+            }
+
+            is SelectLocationMapIntent.SearchLocation -> {
+                if (coordinate != null) {
+                    val location = searchLocationWithCoordinateUseCase.invoke(
+                        Coordinate(
+                            latitude = coordinate.latitude,
+                            longitude = coordinate.longitude
+                        )
+                    )
+                    reduce {
+                        state.copy(
+                            location = location
+                        )
+                    }
+                }
+            }
+
+            is SelectLocationMapIntent.RequestCameraMove -> {
+                container.stateFlow.value.map?.let { map ->
+                    postSideEffect(SelectLocationMapSideEffect.MoveCamera(map, position))
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/location/map/SelectLocationMapViewModel.kt
@@ -25,7 +25,7 @@ class SelectLocationMapViewModel @Inject constructor(
     }
 
     fun onGloballyPositioned(offset: IntOffset) {
-        SelectLocationMapIntent.StoreMapCenterOffset(offset).post()
+        SelectLocationMapIntent.StoreSelectMarkerOffset(offset).post()
     }
 
     fun onCameraMoveEnd(coordinate: LatLng?) {
@@ -46,7 +46,7 @@ class SelectLocationMapViewModel @Inject constructor(
                 }
             }
 
-            is SelectLocationMapIntent.StoreMapCenterOffset -> {
+            is SelectLocationMapIntent.StoreSelectMarkerOffset -> {
                 reduce {
                     state.copy(
                         selectMarkerOffset = offset,


### PR DESCRIPTION
### 개요
- 위치 설정 화면에서 검색어로 검색하거나 버튼을 통해 지도검색 화면으로 이동하여 위치를 지정할 수 있다.
### 변경사항
- 위치 설정 화면에서 검색어로 검색
- 지도검색 화면에서 지도를 끌어서 마커 위치에 대한 주소가 하단에 뜬다.

![123123123](https://github.com/Weit-2nd/roady-foody-android/assets/69796976/471439f1-06f7-4cf9-943d-01a57e219b19)

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-32) 

### 리뷰어에게 하고 싶은 말
- 만들어놓은 MapScreen을 매번 Map이 사용될 때 마다 가져다가 쓰면 MapScreen이 너무 복잡해질 것이라 판단하여 MapScreen에는 메인 화면에서의 역할만을 갖고, 나머지 기능에서의 map들은 따로따로 만드는 것이 낫겠다 생각했습니다.
- 서버에 요청해서 받아오는 값을 Location이라고 지었습니다
