### PR TITLE
ROFO-54 회원가입 api 연결

### DIFF
--- a/data/src/main/java/com/weit2nd/data/di/SignUpModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/SignUpModule.kt
@@ -1,6 +1,10 @@
 package com.weit2nd.data.di
 
+import com.squareup.moshi.Moshi
 import com.weit2nd.data.repository.signup.SignUpRepositoryImpl
+import com.weit2nd.data.service.CheckNicknameService
+import com.weit2nd.data.service.SignUpService
+import com.weit2nd.data.source.localimage.LocalImageDatasource
 import com.weit2nd.data.source.signup.SignUpDataSource
 import com.weit2nd.domain.repository.signup.SignUpRepository
 import dagger.Module
@@ -8,6 +12,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.android.scopes.ViewModelScoped
+import retrofit2.Retrofit
 
 @Module
 @InstallIn(ViewModelComponent::class)
@@ -17,15 +22,41 @@ object SignUpModule {
     @Provides
     fun providesSignUpRepository(
         signUpDataSource: SignUpDataSource,
+        localImageDatasource: LocalImageDatasource,
+        moshi: Moshi,
     ): SignUpRepository {
         return SignUpRepositoryImpl(
             signUpDataSource = signUpDataSource,
+            localImageDatasource = localImageDatasource,
+            moshi = moshi,
         )
     }
 
     @ViewModelScoped
     @Provides
-    fun providesSignUpDataSource(): SignUpDataSource {
-        return SignUpDataSource()
+    fun providesSignUpDataSource(
+        signUpService: SignUpService,
+        checkNicknameService: CheckNicknameService,
+    ): SignUpDataSource {
+        return SignUpDataSource(
+            signUpService = signUpService,
+            checkNicknameService = checkNicknameService,
+        )
+    }
+
+    @Provides
+    @ViewModelScoped
+    fun providesUserRegistrationService(
+        @AuthNetwork retrofit: Retrofit,
+    ): SignUpService {
+        return retrofit.create(SignUpService::class.java)
+    }
+
+    @Provides
+    @ViewModelScoped
+    fun providesCheckNicknameService(
+        @DefaultNetwork retrofit: Retrofit,
+    ): CheckNicknameService {
+        return retrofit.create(CheckNicknameService::class.java)
     }
 }

--- a/data/src/main/java/com/weit2nd/data/interceptor/AuthInterceptor.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/AuthInterceptor.kt
@@ -5,12 +5,11 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
-// TODO 로그인 기능이 추가 되면 에러 핸들링 및 토큰 갱신 기능 추가
 class AuthInterceptor @Inject constructor(
     private val dataSource: AuthDataSource,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val authorization = dataSource.getToken().toString()
+        val authorization = BEARER_PREFIX + dataSource.getAccessToken()
         val newRequest = chain.request().newBuilder().apply {
             addHeader(AUTHORIZATION_HEADER, authorization)
         }
@@ -18,7 +17,7 @@ class AuthInterceptor @Inject constructor(
     }
 
     companion object {
-        private const val AUTHORIZATION_HEADER = "userId"
+        private const val AUTHORIZATION_HEADER = "Authorization"
         private const val BEARER_PREFIX = "Bearer "
     }
 }

--- a/data/src/main/java/com/weit2nd/data/model/user/CheckNicknameDTO.kt
+++ b/data/src/main/java/com/weit2nd/data/model/user/CheckNicknameDTO.kt
@@ -1,0 +1,9 @@
+package com.weit2nd.data.model.user
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class CheckNicknameDTO(
+    @Json(name = "isDuplicated") val isDuplicated: Boolean,
+)

--- a/data/src/main/java/com/weit2nd/data/model/user/SignUpRequest.kt
+++ b/data/src/main/java/com/weit2nd/data/model/user/SignUpRequest.kt
@@ -1,6 +1,6 @@
 package com.weit2nd.data.model.user
 
-data class SingUpRequest(
+data class SignUpRequest(
     val nickname: String,
     val agreedTermIds: List<Long>,
 )

--- a/data/src/main/java/com/weit2nd/data/model/user/SingUpRequest.kt
+++ b/data/src/main/java/com/weit2nd/data/model/user/SingUpRequest.kt
@@ -1,0 +1,6 @@
+package com.weit2nd.data.model.user
+
+data class SingUpRequest(
+    val nickname: String,
+    val agreedTermIds: List<Long>,
+)

--- a/data/src/main/java/com/weit2nd/data/repository/signup/SignUpRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/signup/SignUpRepositoryImpl.kt
@@ -1,15 +1,70 @@
 package com.weit2nd.data.repository.signup
 
+import com.squareup.moshi.Moshi
+import com.weit2nd.data.model.user.SingUpRequest
+import com.weit2nd.data.source.localimage.LocalImageDatasource
 import com.weit2nd.data.source.signup.SignUpDataSource
+import com.weit2nd.data.util.getMultiPart
+import com.weit2nd.domain.exception.user.SignUpException
 import com.weit2nd.domain.model.NicknameState
 import com.weit2nd.domain.repository.signup.SignUpRepository
+import okhttp3.internal.http.HTTP_BAD_REQUEST
+import okhttp3.internal.http.HTTP_CONFLICT
+import okhttp3.internal.http.HTTP_UNAUTHORIZED
+import retrofit2.HttpException
 import javax.inject.Inject
 
 class SignUpRepositoryImpl @Inject constructor(
     private val signUpDataSource: SignUpDataSource,
+    private val localImageDatasource: LocalImageDatasource,
+    private val moshi: Moshi,
 ) : SignUpRepository {
 
     private val nicknameCondition = '가'..'힣'
+
+    override suspend fun registerUser(
+        image: String,
+        nickname: String,
+        agreedTermIds: List<Long>,
+    ) {
+        val imagePart = localImageDatasource.getImageMultipartBodyPart(
+            uri = image,
+            formDataName = "profileImage",
+            imageName = System.currentTimeMillis().toString(),
+        )
+        val request = SingUpRequest(
+            nickname = nickname,
+            agreedTermIds = agreedTermIds,
+        )
+        val signUpPart = moshi.adapter(SingUpRequest::class.java).getMultiPart(
+            formDataName = "signUpRequest",
+            fileName = "signUpRequest",
+            request = request,
+        )
+        runCatching {
+            signUpDataSource.signUp(
+                image = imagePart,
+                signUpRequest = signUpPart,
+            )
+        }.onFailure {
+            throwSignUpException(it)
+        }
+    }
+
+    private fun throwSignUpException(throwable: Throwable) {
+        val message = throwable.message.toString()
+        val exception = if (throwable is HttpException) {
+            when (throwable.code()) {
+                HTTP_BAD_REQUEST -> SignUpException.BadRequestException(message)
+                HTTP_UNAUTHORIZED -> SignUpException.InvalidTokenException(message)
+                HTTP_CONFLICT -> SignUpException.DuplicateUserException(message)
+                else -> throwable
+            }
+        } else {
+            throwable
+        }
+        throw exception
+    }
 
     override fun verifyNickname(nickname: String): NicknameState {
         return when {
@@ -29,7 +84,7 @@ class SignUpRepositoryImpl @Inject constructor(
             return nicknameState
         }
 
-        return if (signUpDataSource.checkNicknameValidation(nickname)) {
+        return if (signUpDataSource.checkNicknameDuplication(nickname).isDuplicated) {
             NicknameState.DUPLICATE
         } else {
             NicknameState.CAN_SIGN_UP

--- a/data/src/main/java/com/weit2nd/data/repository/signup/SignUpRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/signup/SignUpRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.weit2nd.data.repository.signup
 
 import com.squareup.moshi.Moshi
-import com.weit2nd.data.model.user.SingUpRequest
+import com.weit2nd.data.model.user.SignUpRequest
 import com.weit2nd.data.source.localimage.LocalImageDatasource
 import com.weit2nd.data.source.signup.SignUpDataSource
 import com.weit2nd.data.util.getMultiPart
@@ -32,11 +32,11 @@ class SignUpRepositoryImpl @Inject constructor(
             formDataName = "profileImage",
             imageName = System.currentTimeMillis().toString(),
         )
-        val request = SingUpRequest(
+        val request = SignUpRequest(
             nickname = nickname,
             agreedTermIds = agreedTermIds,
         )
-        val signUpPart = moshi.adapter(SingUpRequest::class.java).getMultiPart(
+        val signUpPart = moshi.adapter(SignUpRequest::class.java).getMultiPart(
             formDataName = "signUpRequest",
             fileName = "signUpRequest",
             request = request,

--- a/data/src/main/java/com/weit2nd/data/service/CheckNicknameService.kt
+++ b/data/src/main/java/com/weit2nd/data/service/CheckNicknameService.kt
@@ -1,0 +1,12 @@
+package com.weit2nd.data.service
+
+import com.weit2nd.data.model.user.CheckNicknameDTO
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface CheckNicknameService {
+    @GET("/api/v1/auth/check-nickname")
+    suspend fun checkNickname(
+        @Query("nickname") nickname: String,
+    ): CheckNicknameDTO
+}

--- a/data/src/main/java/com/weit2nd/data/service/SignUpService.kt
+++ b/data/src/main/java/com/weit2nd/data/service/SignUpService.kt
@@ -1,0 +1,16 @@
+package com.weit2nd.data.service
+
+import okhttp3.MultipartBody
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+interface SignUpService {
+
+    @Multipart
+    @POST("/api/v1/auth")
+    suspend fun signUp(
+        @Part signUp: MultipartBody.Part,
+        @Part image: MultipartBody.Part,
+    )
+}

--- a/data/src/main/java/com/weit2nd/data/source/auth/AuthDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/auth/AuthDataSource.kt
@@ -1,9 +1,10 @@
 package com.weit2nd.data.source.auth
 
-class AuthDataSource {
+import com.kakao.sdk.auth.AuthApiClient
+import com.weit2nd.domain.exception.auth.AuthException
 
-    // TODO 로그인이 만들어지면 로그인 토큰을 가져오는 로직으로 변경
-    fun getToken(): Long {
-        return 12321
-    }
+class AuthDataSource {
+    fun getAccessToken(): String =
+        AuthApiClient.instance.tokenManagerProvider.manager.getToken()?.accessToken
+            ?: throw AuthException.TokenNotFoundException()
 }

--- a/data/src/main/java/com/weit2nd/data/source/pickimage/PickImageActivity.kt
+++ b/data/src/main/java/com/weit2nd/data/source/pickimage/PickImageActivity.kt
@@ -1,5 +1,6 @@
 package com.weit2nd.data.source.pickimage
 
+import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.activity.result.PickVisualMediaRequest
@@ -21,14 +22,24 @@ class PickImageActivity : AppCompatActivity() {
         val maximumSelect = intent.getIntExtra(MAXIMUM_SELECT_KEY, 1)
         val pickMedia = if (maximumSelect > 1) {
             registerForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(maximumSelect)) { images ->
+                images.forEach {
+                    takeUriPermission(it)
+                }
                 sendSelectedImagesAndFinish(images)
             }
         } else {
             registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { image ->
+                image?.let {
+                    takeUriPermission(it)
+                }
                 sendSelectedImagesAndFinish(listOfNotNull(image))
             }
         }
         pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+    }
+
+    private fun takeUriPermission(image: Uri) {
+        contentResolver.takePersistableUriPermission(image, Intent.FLAG_GRANT_READ_URI_PERMISSION)
     }
 
     private fun sendSelectedImagesAndFinish(

--- a/data/src/main/java/com/weit2nd/data/source/signup/SignUpDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/signup/SignUpDataSource.kt
@@ -1,11 +1,29 @@
 package com.weit2nd.data.source.signup
 
-import kotlinx.coroutines.delay
+import com.weit2nd.data.model.user.CheckNicknameDTO
+import com.weit2nd.data.service.CheckNicknameService
+import com.weit2nd.data.service.SignUpService
+import okhttp3.MultipartBody
+import javax.inject.Inject
 
-class SignUpDataSource {
+class SignUpDataSource @Inject constructor(
+    private val signUpService: SignUpService,
+    private val checkNicknameService: CheckNicknameService,
+) {
 
-    suspend fun checkNicknameValidation(nickname: String): Boolean {
-        delay(1000)
-        return false
+    suspend fun signUp(
+        image: MultipartBody.Part,
+        signUpRequest: MultipartBody.Part,
+    ) {
+        signUpService.signUp(
+            signUp = signUpRequest,
+            image = image,
+        )
+    }
+
+    suspend fun checkNicknameDuplication(
+        nickname: String,
+    ): CheckNicknameDTO {
+        return checkNicknameService.checkNickname(nickname)
     }
 }

--- a/data/src/main/java/com/weit2nd/data/util/GetMultipart.kt
+++ b/data/src/main/java/com/weit2nd/data/util/GetMultipart.kt
@@ -1,0 +1,23 @@
+package com.weit2nd.data.util
+
+import com.squareup.moshi.JsonAdapter
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
+
+private val defaultMediaType = "application/json".toMediaType()
+
+fun <T> JsonAdapter<T>.getMultiPart(
+    formDataName: String,
+    fileName: String,
+    request: T,
+    mediaType: MediaType = defaultMediaType,
+): MultipartBody.Part {
+    val requestBody = this.toJson(request).toRequestBody(mediaType)
+    return MultipartBody.Part.createFormData(
+        name = formDataName,
+        filename = fileName,
+        body = requestBody,
+    )
+}

--- a/domain/src/main/java/com/weit2nd/domain/exception/auth/AuthException.kt
+++ b/domain/src/main/java/com/weit2nd/domain/exception/auth/AuthException.kt
@@ -1,0 +1,5 @@
+package com.weit2nd.domain.exception.auth
+
+sealed class AuthException : Throwable() {
+    class TokenNotFoundException : AuthException()
+}

--- a/domain/src/main/java/com/weit2nd/domain/exception/user/SignUpException.kt
+++ b/domain/src/main/java/com/weit2nd/domain/exception/user/SignUpException.kt
@@ -1,0 +1,18 @@
+package com.weit2nd.domain.exception.user
+
+sealed class SignUpException(
+    message: String,
+) : Throwable(message) {
+
+    class BadRequestException(
+        message: String,
+    ) : SignUpException(message)
+
+    class DuplicateUserException(
+        message: String,
+    ) : SignUpException(message)
+
+    class InvalidTokenException(
+        message: String,
+    ) : SignUpException(message)
+}

--- a/domain/src/main/java/com/weit2nd/domain/repository/signup/SignUpRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/signup/SignUpRepository.kt
@@ -4,6 +4,12 @@ import com.weit2nd.domain.model.NicknameState
 
 interface SignUpRepository {
 
+    suspend fun registerUser(
+        image: String,
+        nickname: String,
+        agreedTermIds: List<Long>,
+    )
+
     fun verifyNickname(nickname: String): NicknameState
 
     suspend fun checkNicknameValidation(nickname: String): NicknameState

--- a/domain/src/main/java/com/weit2nd/domain/usecase/signup/SignUpUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/signup/SignUpUseCase.kt
@@ -1,0 +1,27 @@
+package com.weit2nd.domain.usecase.signup
+
+import com.weit2nd.domain.repository.signup.SignUpRepository
+import javax.inject.Inject
+
+class SignUpUseCase @Inject constructor(
+    private val repository: SignUpRepository,
+) {
+
+    /**
+     * 회원가입을 합니다.
+     * @param image 프로필 사진 uri
+     * @param nickname 유저 닉네임
+     * @param agreedTermIds 동의한 약관 리스트
+     */
+    suspend operator fun invoke(
+        image: String,
+        nickname: String,
+        agreedTermIds: List<Long>,
+    ) {
+        repository.registerUser(
+            image = image,
+            nickname = nickname,
+            agreedTermIds = agreedTermIds,
+        )
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/signup/VerifyNicknameUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/signup/VerifyNicknameUseCase.kt
@@ -8,7 +8,7 @@ class VerifyNicknameUseCase @Inject constructor(
     val repository: SignUpRepository,
 ) {
 
-    suspend operator fun invoke(nickname: String): NicknameState {
+    operator fun invoke(nickname: String): NicknameState {
         return repository.verifyNickname(nickname)
     }
 }


### PR DESCRIPTION
### 개요
회원가입 api 연결

### 변경사항
- 회원가입 & 닉넴 체크 api 연결
- 액세스 토큰 주입 기능 개발 (인터셉터)
- Picker로 받아온 이미지 uri의 읽기 권한 획득 동작 추가
  - 받아온 uri을 contentResolver로 조물거리니까 권한 문제로 터졌음..

### 관련 지라 및 위키 링크
 - [ROFO-54](https://weit-2nd.atlassian.net/browse/ROFO-54) 


### 리뷰어에게 하고 싶은 말
- 이미지가 들어간 요청을 다루기 때문에 코드가 쫌 깁니다
- 회원가입 잘되는거 확인했읍니다.
  - 아직 탈퇴할 방법이 없기 때문에 일회용 테스트 ㅋㅋ

[ROFO-54]: https://weit-2nd.atlassian.net/browse/ROFO-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ