### PR TITLE
ROFO-61 음식점 리포트 API 연결

### DIFF
--- a/data/src/main/java/com/weit2nd/data/di/SpotModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/SpotModule.kt
@@ -1,0 +1,49 @@
+package com.weit2nd.data.di
+
+import com.squareup.moshi.Moshi
+import com.weit2nd.data.repository.spot.FoodSpotRepositoryImpl
+import com.weit2nd.data.service.SpotService
+import com.weit2nd.data.source.localimage.LocalImageDatasource
+import com.weit2nd.data.source.spot.FoodSpotDataSource
+import com.weit2nd.domain.repository.spot.FoodSpotRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+import retrofit2.Retrofit
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object SpotModule {
+
+    @Provides
+    @ViewModelScoped
+    fun providesFoodSpotRepository(
+        foodSpotDataSource: FoodSpotDataSource,
+        localImageDatasource: LocalImageDatasource,
+        moshi: Moshi,
+    ): FoodSpotRepository {
+        return FoodSpotRepositoryImpl(
+            foodSpotDataSource = foodSpotDataSource,
+            localImageDatasource = localImageDatasource,
+            moshi = moshi,
+        )
+    }
+
+    @Provides
+    @ViewModelScoped
+    fun providesFoodSpotDataSource(
+        service: SpotService,
+    ): FoodSpotDataSource {
+        return FoodSpotDataSource(service)
+    }
+
+    @Provides
+    @ViewModelScoped
+    fun providesFoodSpotService(
+        @AuthNetwork retrofit: Retrofit,
+    ): SpotService {
+        return retrofit.create(SpotService::class.java)
+    }
+}

--- a/data/src/main/java/com/weit2nd/data/model/spot/ReportFoodSpotRequest.kt
+++ b/data/src/main/java/com/weit2nd/data/model/spot/ReportFoodSpotRequest.kt
@@ -1,0 +1,11 @@
+package com.weit2nd.data.model.spot
+
+// TODO 100퍼 바뀜
+data class ReportFoodSpotRequest(
+    val name: String,
+    val longitude: Double,
+    val latitude: Double,
+    val foodTruck: Boolean,
+    val open: Boolean,
+    val closed: Boolean,
+)

--- a/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
@@ -1,0 +1,59 @@
+package com.weit2nd.data.repository.spot
+
+import com.squareup.moshi.Moshi
+import com.weit2nd.data.model.spot.ReportFoodSpotRequest
+import com.weit2nd.data.source.localimage.LocalImageDatasource
+import com.weit2nd.data.source.spot.FoodSpotDataSource
+import com.weit2nd.data.util.getMultiPart
+import com.weit2nd.domain.repository.spot.FoodSpotRepository
+import javax.inject.Inject
+
+class FoodSpotRepositoryImpl @Inject constructor(
+    private val foodSpotDataSource: FoodSpotDataSource,
+    private val localImageDatasource: LocalImageDatasource,
+    private val moshi: Moshi,
+) : FoodSpotRepository {
+    override suspend fun reportFoodSpot(
+        name: String,
+        longitude: Double,
+        latitude: Double,
+        isFoodTruck: Boolean,
+        open: Boolean,
+        closed: Boolean,
+        images: List<String>,
+    ) {
+        val imageParts = images.map { image ->
+            localImageDatasource.getImageMultipartBodyPart(
+                uri = image,
+                formDataName = "reportPhotos",
+                imageName = System.nanoTime().toString(),
+            )
+        }.takeIf { it.isNotEmpty() }
+        val request = ReportFoodSpotRequest(
+            name = name,
+            longitude = longitude,
+            latitude = latitude,
+            foodTruck = isFoodTruck,
+            open = open,
+            closed = closed,
+        )
+        val reportFoodSpotPart = moshi.adapter(ReportFoodSpotRequest::class.java).getMultiPart(
+            formDataName = "reportRequest",
+            fileName = "reportRequest",
+            request = request,
+        )
+        foodSpotDataSource.reportFoodSpot(
+            reportRequest = reportFoodSpotPart,
+            reportPhotos = imageParts,
+        )
+    }
+
+    override suspend fun verifyReport(
+        name: String,
+        longitude: Double,
+        latitude: Double,
+        images: List<String>,
+    ) {
+        TODO("Not yet implemented")
+    }
+}

--- a/data/src/main/java/com/weit2nd/data/service/SpotService.kt
+++ b/data/src/main/java/com/weit2nd/data/service/SpotService.kt
@@ -1,0 +1,15 @@
+package com.weit2nd.data.service
+
+import okhttp3.MultipartBody
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+interface SpotService {
+    @Multipart
+    @POST("/api/v1/auth")
+    suspend fun reportFoodSpot(
+        @Part reportRequest: MultipartBody.Part,
+        @Part reportPhotos: List<MultipartBody.Part>?,
+    )
+}

--- a/data/src/main/java/com/weit2nd/data/service/SpotService.kt
+++ b/data/src/main/java/com/weit2nd/data/service/SpotService.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Part
 
 interface SpotService {
     @Multipart
-    @POST("/api/v1/auth")
+    @POST("/api/v1/food-spots")
     suspend fun reportFoodSpot(
         @Part reportRequest: MultipartBody.Part,
         @Part reportPhotos: List<MultipartBody.Part>?,

--- a/data/src/main/java/com/weit2nd/data/source/spot/FoodSpotDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/spot/FoodSpotDataSource.kt
@@ -1,0 +1,21 @@
+package com.weit2nd.data.source.spot
+
+import com.weit2nd.data.service.SpotService
+import okhttp3.MultipartBody
+import retrofit2.http.Part
+import javax.inject.Inject
+
+class FoodSpotDataSource @Inject constructor(
+    private val service: SpotService,
+) {
+
+    suspend fun reportFoodSpot(
+        reportRequest: MultipartBody.Part,
+        reportPhotos: List<MultipartBody.Part>?,
+    ) {
+        service.reportFoodSpot(
+            reportRequest = reportRequest,
+            reportPhotos = reportPhotos,
+        )
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/ReportFoodSpotState.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/ReportFoodSpotState.kt
@@ -1,0 +1,10 @@
+package com.weit2nd.domain.model.spot
+
+sealed class ReportFoodSpotState {
+    data object BadCoordinateState : ReportFoodSpotState()
+    data object BadFoodSpotNameState : ReportFoodSpotState()
+    data object TooManyImagesState : ReportFoodSpotState()
+    data class InvalidImageState(
+        val uri: String,
+    ) : ReportFoodSpotState()
+}

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/ReportFoodSpotState.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/ReportFoodSpotState.kt
@@ -1,10 +1,11 @@
 package com.weit2nd.domain.model.spot
 
 sealed class ReportFoodSpotState {
-    data object BadCoordinateState : ReportFoodSpotState()
-    data object BadFoodSpotNameState : ReportFoodSpotState()
-    data object TooManyImagesState : ReportFoodSpotState()
-    data class InvalidImageState(
+    data object BadCoordinate : ReportFoodSpotState()
+    data object BadFoodSpotName : ReportFoodSpotState()
+    data object TooManyImages : ReportFoodSpotState()
+    data class InvalidImage(
         val uri: String,
     ) : ReportFoodSpotState()
+    data object Valid : ReportFoodSpotState()
 }

--- a/domain/src/main/java/com/weit2nd/domain/repository/spot/FoodSpotRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/spot/FoodSpotRepository.kt
@@ -1,0 +1,20 @@
+package com.weit2nd.domain.repository.spot
+
+interface FoodSpotRepository {
+    suspend fun reportFoodSpot(
+        name: String,
+        longitude: Double,
+        latitude: Double,
+        isFoodTruck: Boolean,
+        open: Boolean,
+        closed: Boolean,
+        images: List<String>,
+    )
+
+    suspend fun verifyReport(
+        name: String,
+        longitude: Double,
+        latitude: Double,
+        images: List<String>,
+    )
+}

--- a/domain/src/main/java/com/weit2nd/domain/repository/spot/FoodSpotRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/spot/FoodSpotRepository.kt
@@ -1,5 +1,7 @@
 package com.weit2nd.domain.repository.spot
 
+import com.weit2nd.domain.model.spot.ReportFoodSpotState
+
 interface FoodSpotRepository {
     suspend fun reportFoodSpot(
         name: String,
@@ -16,5 +18,5 @@ interface FoodSpotRepository {
         longitude: Double,
         latitude: Double,
         images: List<String>,
-    )
+    ): ReportFoodSpotState
 }

--- a/domain/src/main/java/com/weit2nd/domain/usecase/spot/ReportFoodSpotUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/spot/ReportFoodSpotUseCase.kt
@@ -1,0 +1,44 @@
+package com.weit2nd.domain.usecase.spot
+
+import com.weit2nd.domain.repository.spot.FoodSpotRepository
+import javax.inject.Inject
+
+class ReportFoodSpotUseCase @Inject constructor(
+    private val repository: FoodSpotRepository,
+) {
+
+    /**
+     * 음식점을 등록 합니다.
+     * @see Params
+     */
+    suspend operator fun invoke(params: Params) {
+        repository.reportFoodSpot(
+            name = params.name,
+            longitude = params.longitude,
+            latitude = params.latitude,
+            isFoodTruck = params.isFoodTruck,
+            open = params.open,
+            closed = params.closed,
+            images = params.images,
+        )
+    }
+
+    /**
+     * @param name 음식점 이름
+     * @param longitude 음식점 좌표 (경도)
+     * @param latitude 음식점 좌표 (위도)
+     * @param isFoodTruck 음식점이 푸드트럭 인지
+     * @param open 현재 영업 중
+     * @param closed 폐업
+     * @param images 음식점 이미지
+     */
+    data class Params(
+        val name: String,
+        val longitude: Double,
+        val latitude: Double,
+        val isFoodTruck: Boolean,
+        val open: Boolean,
+        val closed: Boolean,
+        val images: List<String>,
+    )
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/spot/ReportFoodSpotUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/spot/ReportFoodSpotUseCase.kt
@@ -6,24 +6,8 @@ import javax.inject.Inject
 class ReportFoodSpotUseCase @Inject constructor(
     private val repository: FoodSpotRepository,
 ) {
-
     /**
      * 음식점을 등록 합니다.
-     * @see Params
-     */
-    suspend operator fun invoke(params: Params) {
-        repository.reportFoodSpot(
-            name = params.name,
-            longitude = params.longitude,
-            latitude = params.latitude,
-            isFoodTruck = params.isFoodTruck,
-            open = params.open,
-            closed = params.closed,
-            images = params.images,
-        )
-    }
-
-    /**
      * @param name 음식점 이름
      * @param longitude 음식점 좌표 (경도)
      * @param latitude 음식점 좌표 (위도)
@@ -32,13 +16,23 @@ class ReportFoodSpotUseCase @Inject constructor(
      * @param closed 폐업
      * @param images 음식점 이미지
      */
-    data class Params(
-        val name: String,
-        val longitude: Double,
-        val latitude: Double,
-        val isFoodTruck: Boolean,
-        val open: Boolean,
-        val closed: Boolean,
-        val images: List<String>,
-    )
+    suspend operator fun invoke(
+        name: String,
+        longitude: Double,
+        latitude: Double,
+        isFoodTruck: Boolean,
+        open: Boolean,
+        closed: Boolean,
+        images: List<String>,
+    ) {
+        repository.reportFoodSpot(
+            name = name,
+            longitude = longitude,
+            latitude = latitude,
+            isFoodTruck = isFoodTruck,
+            open = open,
+            closed = closed,
+            images = images,
+        )
+    }
 }

--- a/domain/src/main/java/com/weit2nd/domain/usecase/spot/VerifyReportUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/spot/VerifyReportUseCase.kt
@@ -9,26 +9,22 @@ class VerifyReportUseCase @Inject constructor(
 ) {
     /**
      * 현재 작성한 음식점 리포트 정보가 유효한지 검사합니다.
-     */
-    suspend operator fun invoke(params: Params): ReportFoodSpotState {
-        return repository.verifyReport(
-            params.name,
-            params.longitude,
-            params.latitude,
-            params.images,
-        )
-    }
-
-    /**
      * @param name 음식점 이름
      * @param longitude 음식점 좌표 (경도)
      * @param latitude 음식점 좌표 (위도)
      * @param images 음식점 이미지
      */
-    data class Params(
-        val name: String,
-        val longitude: Double,
-        val latitude: Double,
-        val images: List<String>,
-    )
+    suspend operator fun invoke(
+        name: String,
+        longitude: Double,
+        latitude: Double,
+        images: List<String>,
+    ): ReportFoodSpotState {
+        return repository.verifyReport(
+            name = name,
+            longitude = longitude,
+            latitude = latitude,
+            images = images,
+        )
+    }
 }

--- a/domain/src/main/java/com/weit2nd/domain/usecase/spot/VerifyReportUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/spot/VerifyReportUseCase.kt
@@ -1,0 +1,34 @@
+package com.weit2nd.domain.usecase.spot
+
+import com.weit2nd.domain.model.spot.ReportFoodSpotState
+import com.weit2nd.domain.repository.spot.FoodSpotRepository
+import javax.inject.Inject
+
+class VerifyReportUseCase @Inject constructor(
+    private val repository: FoodSpotRepository,
+) {
+    /**
+     * 현재 작성한 음식점 리포트 정보가 유효한지 검사합니다.
+     */
+    suspend operator fun invoke(params: Params): ReportFoodSpotState {
+        return repository.verifyReport(
+            params.name,
+            params.longitude,
+            params.latitude,
+            params.images,
+        )
+    }
+
+    /**
+     * @param name 음식점 이름
+     * @param longitude 음식점 좌표 (경도)
+     * @param latitude 음식점 좌표 (위도)
+     * @param images 음식점 이미지
+     */
+    data class Params(
+        val name: String,
+        val longitude: Double,
+        val latitude: Double,
+        val images: List<String>,
+    )
+}


### PR DESCRIPTION
### 개요
* 음식점 리포트 API 연결

### 변경사항
- 음식점 리포트 API 연결
- 음식점 리포트 내용 검증 기능 추가 

### 관련 지라 및 위키 링크
 - [ROFO-61](https://weit-2nd.atlassian.net/browse/ROFO-61) 

### 리뷰어에게 하고 싶은 말
- Authorization 헤더 내용이 바뀌었기 때문에 로그인 기능이 완성될때까지 api 테스트가 안됨

[ROFO-61]: https://weit-2nd.atlassian.net/browse/ROFO-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ