### PR TITLE
ROFO-70 스플래쉬 화면

### DIFF
--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -31,6 +31,7 @@ import com.weit2nd.presentation.ui.select.place.map.SelectLocationMapScreen
 import com.weit2nd.presentation.ui.signup.SignUpScreen
 import com.weit2nd.presentation.ui.select.picture.SelectPictureScreen
 import com.weit2nd.presentation.ui.signup.terms.detail.TermDetailScreen
+import com.weit2nd.presentation.ui.splash.SplashScreen
 
 
 @Composable
@@ -41,10 +42,11 @@ fun AppNavHost(
     NavHost(
         modifier = modifier,
         navController = navController,
-        startDestination = LoginNavRoutes.GRAPH,
+        startDestination = SplashRoutes.GRAPH,
         enterTransition = { EnterTransition.None },
         exitTransition = { ExitTransition.None },
     ) {
+        splashComposable(navController)
         loginComposable(navController)
         signUpComposable(navController)
         homeComposable(navController)
@@ -53,6 +55,36 @@ fun AppNavHost(
         selectLocationMapComposable(navController)
         termDetailComposable(navController)
         imageViewerComposable(navController)
+    }
+}
+
+private fun NavGraphBuilder.splashComposable(
+    navController: NavHostController,
+) {
+    composable(SplashRoutes.GRAPH) {
+        SplashScreen(
+            navToLogin = {
+                navController.navigate(LoginNavRoutes.GRAPH) {
+                    popUpTo(SplashRoutes.GRAPH) {
+                        inclusive = true
+                    }
+                }
+            },
+            navToSignUp = {
+                navController.navigate(SignUpNavRoutes.GRAPH) {
+                    popUpTo(SplashRoutes.GRAPH) {
+                        inclusive = true
+                    }
+                }
+            },
+            navToHome = {
+                navController.navigateToHome(User("임시")) {
+                    popUpTo(SplashRoutes.GRAPH) {
+                        inclusive = true
+                    }
+                }
+            },
+        )
     }
 }
 
@@ -191,7 +223,7 @@ private fun NavHostController.navigateToSelectLocationMap(
 
 private fun NavHostController.navigateToTermDetail(
     termId: Long,
-)  {
+) {
     navigate("${TermDetailRoutes.GRAPH}/$termId")
 }
 
@@ -203,6 +235,10 @@ private fun NavHostController.navigateToImageViewer(
     val data = ImageViewerData(images, position)
     val imageDataJson = Uri.encode(Gson().toJson(data.toImageViewerDTO()))
     navigate("${ImageViewerRoutes.GRAPH}/$imageDataJson", builder)
+}
+
+object SplashRoutes {
+    const val GRAPH = "splash"
 }
 
 object LoginNavRoutes {

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -70,13 +70,6 @@ private fun NavGraphBuilder.splashComposable(
                     }
                 }
             },
-            navToSignUp = {
-                navController.navigate(SignUpNavRoutes.GRAPH) {
-                    popUpTo(SplashRoutes.GRAPH) {
-                        inclusive = true
-                    }
-                }
-            },
             navToHome = {
                 navController.navigateToHome(User("임시")) {
                     popUpTo(SplashRoutes.GRAPH) {

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashIntent.kt
@@ -2,6 +2,5 @@ package com.weit2nd.presentation.ui.splash
 
 sealed class SplashIntent {
     data object NavToLogin : SplashIntent()
-    data object NavToSignUp : SplashIntent()
     data object NavToHome : SplashIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashIntent.kt
@@ -1,0 +1,7 @@
+package com.weit2nd.presentation.ui.splash
+
+sealed class SplashIntent {
+    data object NavToLogin : SplashIntent()
+    data object NavToSignUp : SplashIntent()
+    data object NavToHome : SplashIntent()
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashScreen.kt
@@ -1,0 +1,57 @@
+package com.weit2nd.presentation.ui.splash
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.hilt.navigation.compose.hiltViewModel
+import kotlinx.coroutines.delay
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
+
+@Composable
+fun SplashScreen(
+    vm: SplashViewModel = hiltViewModel(),
+    navToLogin: () -> Unit,
+    navToSignUp: () -> Unit,
+    navToHome: () -> Unit,
+) {
+    val state = vm.collectAsState()
+    vm.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            SplashSideEffect.NavToHome -> navToHome()
+            SplashSideEffect.NavToLogin -> navToLogin()
+            SplashSideEffect.NavToSignUp -> navToSignUp()
+        }
+    }
+
+    val alpha = remember {
+        Animatable(0f)
+    }
+    LaunchedEffect(Unit) {
+        alpha.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(1500)
+        )
+        delay(1000L)    // 로그인 시도 시간 임시 설정
+        vm.onSplashEnd()
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .alpha(alpha.value),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "Splash",
+        )
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashScreen.kt
@@ -20,7 +20,6 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 fun SplashScreen(
     vm: SplashViewModel = hiltViewModel(),
     navToLogin: () -> Unit,
-    navToSignUp: () -> Unit,
     navToHome: () -> Unit,
 ) {
     val state = vm.collectAsState()
@@ -28,7 +27,6 @@ fun SplashScreen(
         when (sideEffect) {
             SplashSideEffect.NavToHome -> navToHome()
             SplashSideEffect.NavToLogin -> navToLogin()
-            SplashSideEffect.NavToSignUp -> navToSignUp()
         }
     }
 

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashSideEffect.kt
@@ -2,6 +2,5 @@ package com.weit2nd.presentation.ui.splash
 
 sealed class SplashSideEffect {
     data object NavToLogin : SplashSideEffect()
-    data object NavToSignUp : SplashSideEffect()
     data object NavToHome : SplashSideEffect()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashSideEffect.kt
@@ -1,0 +1,7 @@
+package com.weit2nd.presentation.ui.splash
+
+sealed class SplashSideEffect {
+    data object NavToLogin : SplashSideEffect()
+    data object NavToSignUp : SplashSideEffect()
+    data object NavToHome : SplashSideEffect()
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashState.kt
@@ -1,0 +1,5 @@
+package com.weit2nd.presentation.ui.splash
+
+data class SplashState(
+    val isLoginSuccess: Boolean = false,
+)

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashViewModel.kt
@@ -23,9 +23,6 @@ class SplashViewModel @Inject constructor() : BaseViewModel<SplashState, SplashS
             SplashIntent.NavToLogin -> {
                 postSideEffect(SplashSideEffect.NavToLogin)
             }
-            SplashIntent.NavToSignUp -> {
-                postSideEffect(SplashSideEffect.NavToSignUp)
-            }
         }
     }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/splash/SplashViewModel.kt
@@ -1,0 +1,31 @@
+package com.weit2nd.presentation.ui.splash
+
+import com.weit2nd.presentation.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.viewmodel.container
+import javax.inject.Inject
+
+@HiltViewModel
+class SplashViewModel @Inject constructor() : BaseViewModel<SplashState, SplashSideEffect>() {
+    override val container = container<SplashState, SplashSideEffect>(SplashState())
+
+    fun onSplashEnd() {
+        SplashIntent.NavToLogin.post()  // 임시 이동
+    }
+
+    private fun SplashIntent.post() = intent {
+        when (this@post) {
+            SplashIntent.NavToHome -> {
+                postSideEffect(SplashSideEffect.NavToHome)
+            }
+            SplashIntent.NavToLogin -> {
+                postSideEffect(SplashSideEffect.NavToLogin)
+            }
+            SplashIntent.NavToSignUp -> {
+                postSideEffect(SplashSideEffect.NavToSignUp)
+            }
+        }
+    }
+}

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.RoadyFoody" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.RoadyFoody" parent="android:Theme.Material.Light.NoActionBar">
+        <!--    todo 스플래시 화면의 배경색과 일치하도록 수정    -->
+        <item name="android:windowSplashScreenBackground" tools:targetApi="s">@android:color/transparent</item>
+        <item name="android:windowSplashScreenAnimatedIcon" tools:targetApi="s">@android:color/transparent</item>
+    </style>
 </resources>


### PR DESCRIPTION
### 개요
- 스플래쉬 화면 생성
### 변경사항
- 스플래쉬 화면 생성

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-70) 

### 리뷰어에게 하고 싶은 말
- 스플래쉬 화면에서 스르륵하면서 점점 뚜렷해지게 하는 것을 알파값을 주어서 설정했습니다. [참고블로그](https://dev-inventory.com/m/52)
- [안드로이드12부터 제공하는 디폴트 스플래시를 제거할 수는 없고 edit만 가능하다고 해서](https://stackoverflow.com/questions/67921860/disable-android-12-default-splash-screen) 스플래시 아이콘과 배경을 투명으로 설정했습니다.(나중에 디자인나온 스플래시 화면의 배경색으로 수정해야함)