### PR TITLE
ROFO-73 로그인 API 연결

### DIFF
--- a/data/src/main/java/com/weit2nd/data/di/AuthModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/AuthModule.kt
@@ -1,6 +1,6 @@
 package com.weit2nd.data.di
 
-import com.weit2nd.data.interceptor.AuthInterceptor
+import com.weit2nd.data.interceptor.LoginInterceptor
 import com.weit2nd.data.source.auth.AuthDataSource
 import dagger.Module
 import dagger.Provides
@@ -15,8 +15,8 @@ object AuthModule {
     @Provides
     fun providesAuthInterceptor(
         dataSource: AuthDataSource,
-    ): AuthInterceptor {
-        return AuthInterceptor(dataSource)
+    ): LoginInterceptor {
+        return LoginInterceptor(dataSource)
     }
 
     @Singleton

--- a/data/src/main/java/com/weit2nd/data/di/LoginModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/LoginModule.kt
@@ -39,7 +39,7 @@ object LoginModule {
     @Provides
     @Singleton
     fun providesLoginService(
-        @AuthNetwork retrofit: Retrofit,
+        @LoginNetwork retrofit: Retrofit,
     ): LoginService {
         return retrofit.create(LoginService::class.java)
     }

--- a/data/src/main/java/com/weit2nd/data/di/LoginModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/LoginModule.kt
@@ -8,7 +8,6 @@ import com.weit2nd.domain.repository.login.LoginRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.scopes.ViewModelScoped
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 import javax.inject.Singleton
@@ -31,8 +30,10 @@ object LoginModule {
 
     @Singleton
     @Provides
-    fun providesLoginDataSource(): LoginDataSource {
-        return LoginDataSource()
+    fun providesLoginDataSource(
+        service: LoginService,
+    ): LoginDataSource {
+        return LoginDataSource(service)
     }
 
     @Provides

--- a/data/src/main/java/com/weit2nd/data/di/LoginModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/LoginModule.kt
@@ -1,13 +1,16 @@
 package com.weit2nd.data.di
 
 import com.weit2nd.data.repository.login.LoginRepositoryImpl
+import com.weit2nd.data.service.LoginService
 import com.weit2nd.data.source.login.LoginDataSource
 import com.weit2nd.data.util.ActivityProvider
 import com.weit2nd.domain.repository.login.LoginRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.scopes.ViewModelScoped
 import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
 import javax.inject.Singleton
 
 @Module
@@ -30,5 +33,13 @@ object LoginModule {
     @Provides
     fun providesLoginDataSource(): LoginDataSource {
         return LoginDataSource()
+    }
+
+    @Provides
+    @Singleton
+    fun providesLoginService(
+        @AuthNetwork retrofit: Retrofit,
+    ): LoginService {
+        return retrofit.create(LoginService::class.java)
     }
 }

--- a/data/src/main/java/com/weit2nd/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/NetworkModule.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.weit2nd.data.BuildConfig
 import com.weit2nd.data.R
-import com.weit2nd.data.interceptor.AuthInterceptor
+import com.weit2nd.data.interceptor.LoginInterceptor
 import com.weit2nd.data.interceptor.ErrorResponseInterceptor
 import com.weit2nd.data.util.LocalDateTimeConverter
 import dagger.Module
@@ -47,12 +47,12 @@ object NetworkModule {
     @LoginNetwork
     @Singleton
     @Provides
-    fun provideAuthOkHttpClient(
-        authInterceptor: AuthInterceptor,
+    fun provideLoginOkHttpClient(
+        loginInterceptor: LoginInterceptor,
         loggingInterceptor: HttpLoggingInterceptor,
         errorResponseInterceptor: ErrorResponseInterceptor,
     ): OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(authInterceptor)
+        .addInterceptor(loginInterceptor)
         .addInterceptor(loggingInterceptor)
         .addInterceptor(errorResponseInterceptor)
         .build()
@@ -76,7 +76,7 @@ object NetworkModule {
     @LoginNetwork
     @Singleton
     @Provides
-    fun provideAuthRetrofit(
+    fun provideLoginRetrofit(
         @ApplicationContext context: Context,
         @LoginNetwork okHttpClient: OkHttpClient,
         moshi: Moshi,

--- a/data/src/main/java/com/weit2nd/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/NetworkModule.kt
@@ -27,7 +27,7 @@ annotation class DefaultNetwork
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class AuthNetwork
+annotation class LoginNetwork
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -44,7 +44,7 @@ object NetworkModule {
         .addInterceptor(errorResponseInterceptor)
         .build()
 
-    @AuthNetwork
+    @LoginNetwork
     @Singleton
     @Provides
     fun provideAuthOkHttpClient(
@@ -73,12 +73,12 @@ object NetworkModule {
             .build()
     }
 
-    @AuthNetwork
+    @LoginNetwork
     @Singleton
     @Provides
     fun provideAuthRetrofit(
         @ApplicationContext context: Context,
-        @AuthNetwork okHttpClient: OkHttpClient,
+        @LoginNetwork okHttpClient: OkHttpClient,
         moshi: Moshi,
     ): Retrofit {
         return Retrofit.Builder()

--- a/data/src/main/java/com/weit2nd/data/di/SearchPlaceModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/SearchPlaceModule.kt
@@ -34,7 +34,7 @@ object SearchPlaceModule {
     @ViewModelScoped
     @Provides
     fun providesSearchService(
-        @AuthNetwork retrofit: Retrofit,
+        @LoginNetwork retrofit: Retrofit,
     ): SearchService {
         return retrofit.create(SearchService::class.java)
     }

--- a/data/src/main/java/com/weit2nd/data/di/SignUpModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/SignUpModule.kt
@@ -3,7 +3,7 @@ package com.weit2nd.data.di
 import com.squareup.moshi.Moshi
 import com.weit2nd.data.repository.signup.SignUpRepositoryImpl
 import com.weit2nd.data.service.CheckNicknameService
-import com.weit2nd.data.service.SignUpService
+import com.weit2nd.data.service.LoginService
 import com.weit2nd.data.source.localimage.LocalImageDatasource
 import com.weit2nd.data.source.signup.SignUpDataSource
 import com.weit2nd.domain.repository.signup.SignUpRepository
@@ -35,21 +35,13 @@ object SignUpModule {
     @ViewModelScoped
     @Provides
     fun providesSignUpDataSource(
-        signUpService: SignUpService,
+        loginService: LoginService,
         checkNicknameService: CheckNicknameService,
     ): SignUpDataSource {
         return SignUpDataSource(
-            signUpService = signUpService,
+            loginService = loginService,
             checkNicknameService = checkNicknameService,
         )
-    }
-
-    @Provides
-    @ViewModelScoped
-    fun providesUserRegistrationService(
-        @AuthNetwork retrofit: Retrofit,
-    ): SignUpService {
-        return retrofit.create(SignUpService::class.java)
     }
 
     @Provides

--- a/data/src/main/java/com/weit2nd/data/di/SpotModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/SpotModule.kt
@@ -42,7 +42,7 @@ object SpotModule {
     @Provides
     @ViewModelScoped
     fun providesFoodSpotService(
-        @AuthNetwork retrofit: Retrofit,
+        @LoginNetwork retrofit: Retrofit,
     ): SpotService {
         return retrofit.create(SpotService::class.java)
     }

--- a/data/src/main/java/com/weit2nd/data/di/TermsModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/TermsModule.kt
@@ -34,7 +34,7 @@ object TermsModule {
     @ViewModelScoped
     @Provides
     fun providesTermsService(
-        @AuthNetwork retrofit: Retrofit,
+        @LoginNetwork retrofit: Retrofit,
     ): TermsService {
         return retrofit.create(TermsService::class.java)
     }

--- a/data/src/main/java/com/weit2nd/data/interceptor/ErrorResponseInterceptor.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/ErrorResponseInterceptor.kt
@@ -16,7 +16,6 @@ class ErrorResponseInterceptor @Inject constructor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         val response = chain.proceed(request)
-
         if (!response.isSuccessful) {
             val errorBody = response.peekBody(Long.MAX_VALUE).string()
             val errorResponse: ErrorResponse? = errorAdapter.fromJson(errorBody)

--- a/data/src/main/java/com/weit2nd/data/interceptor/LoginInterceptor.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/LoginInterceptor.kt
@@ -5,7 +5,7 @@ import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
-class AuthInterceptor @Inject constructor(
+class LoginInterceptor @Inject constructor(
     private val dataSource: AuthDataSource,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/data/src/main/java/com/weit2nd/data/interceptor/LoginInterceptor.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/LoginInterceptor.kt
@@ -9,7 +9,7 @@ class LoginInterceptor @Inject constructor(
     private val dataSource: AuthDataSource,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val authorization = BEARER_PREFIX + dataSource.getAccessToken()
+        val authorization = BEARER_PREFIX + dataSource.getSocialAccessToken()
         val newRequest = chain.request().newBuilder().apply {
             addHeader(AUTHORIZATION_HEADER, authorization)
         }

--- a/data/src/main/java/com/weit2nd/data/model/login/LoginToken.kt
+++ b/data/src/main/java/com/weit2nd/data/model/login/LoginToken.kt
@@ -1,0 +1,14 @@
+package com.weit2nd.data.model.login
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * @param accessToken api 인증에 사용하는 토큰
+ * @param refreshToken accessToken 만료시 재발급을 위해 사용하는 토큰
+ */
+@JsonClass(generateAdapter = true)
+data class LoginToken(
+    @Json(name = "accessToken") val accessToken: String,
+    @Json(name = "refreshToken") val refreshToken: String,
+)

--- a/data/src/main/java/com/weit2nd/data/service/LoginService.kt
+++ b/data/src/main/java/com/weit2nd/data/service/LoginService.kt
@@ -5,7 +5,7 @@ import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
 
-interface SignUpService {
+interface LoginService {
 
     @Multipart
     @POST("/api/v1/auth")

--- a/data/src/main/java/com/weit2nd/data/service/LoginService.kt
+++ b/data/src/main/java/com/weit2nd/data/service/LoginService.kt
@@ -1,6 +1,8 @@
 package com.weit2nd.data.service
 
+import com.weit2nd.data.model.login.LoginToken
 import okhttp3.MultipartBody
+import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
@@ -13,4 +15,7 @@ interface LoginService {
         @Part signUp: MultipartBody.Part,
         @Part image: MultipartBody.Part,
     )
+
+    @GET("/api/v1/auth")
+    suspend fun signIn(): LoginToken
 }

--- a/data/src/main/java/com/weit2nd/data/source/auth/AuthDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/auth/AuthDataSource.kt
@@ -4,7 +4,7 @@ import com.kakao.sdk.auth.AuthApiClient
 import com.weit2nd.domain.exception.auth.AuthException
 
 class AuthDataSource {
-    fun getAccessToken(): String =
+    fun getSocialAccessToken(): String =
         AuthApiClient.instance.tokenManagerProvider.manager.getToken()?.accessToken
             ?: throw AuthException.TokenNotFoundException()
 }

--- a/data/src/main/java/com/weit2nd/data/source/login/LoginDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/login/LoginDataSource.kt
@@ -4,13 +4,17 @@ import android.app.Activity
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
+import com.weit2nd.data.model.login.LoginToken
+import com.weit2nd.data.service.LoginService
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-class LoginDataSource @Inject constructor() {
+class LoginDataSource @Inject constructor(
+    private val loginService: LoginService,
+) {
     suspend fun loginWithKakaoTalk(
         activity: Activity,
     ): Result<Unit> = callbackFlow {
@@ -42,7 +46,7 @@ class LoginDataSource @Inject constructor() {
         awaitClose { /* Do Nothing */ }
     }.first()
 
-    suspend fun loginToServer() {
-        // TODO: 6/2/24 (minseonglove) 서버 로그인
+    suspend fun loginToServer(): LoginToken {
+        return loginService.signIn()
     }
 }

--- a/data/src/main/java/com/weit2nd/data/source/signup/SignUpDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/signup/SignUpDataSource.kt
@@ -2,12 +2,12 @@ package com.weit2nd.data.source.signup
 
 import com.weit2nd.data.model.user.CheckNicknameDTO
 import com.weit2nd.data.service.CheckNicknameService
-import com.weit2nd.data.service.SignUpService
+import com.weit2nd.data.service.LoginService
 import okhttp3.MultipartBody
 import javax.inject.Inject
 
 class SignUpDataSource @Inject constructor(
-    private val signUpService: SignUpService,
+    private val loginService: LoginService,
     private val checkNicknameService: CheckNicknameService,
 ) {
 
@@ -15,7 +15,7 @@ class SignUpDataSource @Inject constructor(
         image: MultipartBody.Part,
         signUpRequest: MultipartBody.Part,
     ) {
-        signUpService.signUp(
+        loginService.signUp(
             signUp = signUpRequest,
             image = image,
         )

--- a/domain/src/main/java/com/weit2nd/domain/exception/UnknownException.kt
+++ b/domain/src/main/java/com/weit2nd/domain/exception/UnknownException.kt
@@ -1,0 +1,3 @@
+package com.weit2nd.domain.exception
+
+class UnknownException : Throwable()

--- a/domain/src/main/java/com/weit2nd/domain/exception/user/LoginException.kt
+++ b/domain/src/main/java/com/weit2nd/domain/exception/user/LoginException.kt
@@ -1,0 +1,15 @@
+package com.weit2nd.domain.exception.user
+
+sealed class LoginException : Throwable() {
+    /**
+     * 회원 가입이 안된 상태
+     */
+    class UserNotFoundException : LoginException()
+
+    /**
+     * 소셜 로그인 토큰이 만료된 상태
+     *
+     * 소셜 로그인을 다시 시도해주세요
+     */
+    class InvalidTokenException : LoginException()
+}

--- a/domain/src/main/java/com/weit2nd/domain/repository/login/LoginRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/login/LoginRepository.kt
@@ -2,4 +2,6 @@ package com.weit2nd.domain.repository.login
 
 interface LoginRepository {
     suspend fun loginWithKakao(): Result<Unit>
+
+    suspend fun loginToServer(): Result<Unit>
 }

--- a/domain/src/main/java/com/weit2nd/domain/usecase/login/LoginToServerUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/login/LoginToServerUseCase.kt
@@ -1,0 +1,18 @@
+package com.weit2nd.domain.usecase.login
+
+import com.weit2nd.domain.repository.login.LoginRepository
+import javax.inject.Inject
+
+class LoginToServerUseCase @Inject constructor(
+    private val repository: LoginRepository,
+) {
+
+    /**
+     * 우리 서버로 바로 로그인 합니다.
+     *
+     * 스플래쉬 화면에서 자동 로그인을 시도할 때 사용
+     */
+    suspend operator fun invoke(): Result<Unit> {
+        return repository.loginToServer()
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/login/LoginWithKakaoUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/login/LoginWithKakaoUseCase.kt
@@ -3,9 +3,15 @@ package com.weit2nd.domain.usecase.login
 import com.weit2nd.domain.repository.login.LoginRepository
 import javax.inject.Inject
 
-class LoginUseCase @Inject constructor(
+class LoginWithKakaoUseCase @Inject constructor(
     private val repository: LoginRepository,
 ) {
+
+    /**
+     * 카카오로 로그인 합니다.
+     *
+     * 로그인 화면 또는 스플래쉬 화면에서 소셜 토큰이 만료됐을 때 사용
+     */
     suspend operator fun invoke(): Result<Unit> {
         return repository.loginWithKakao()
     }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/login/LoginViewModel.kt
@@ -29,6 +29,9 @@ class LoginViewModel @Inject constructor(
                         isLoading = true,
                     )
                 }
+                // TODO 로그인 UseCase는 Result로 반환되므로 runCatching 제거
+                // TODO 로그인 성공시 메인 화면으로 이동
+                // TODO UserNotFoundException이면 회원가입으로 이동
                 runCatching {
                     loginWithKakaoUseCase.invoke().getOrThrow()
                 }.onSuccess {

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/login/LoginViewModel.kt
@@ -1,7 +1,7 @@
 package com.weit2nd.presentation.ui.login
 
 import android.util.Log
-import com.weit2nd.domain.usecase.login.LoginUseCase
+import com.weit2nd.domain.usecase.login.LoginWithKakaoUseCase
 import com.weit2nd.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -12,7 +12,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val loginUseCase: LoginUseCase,
+    private val loginWithKakaoUseCase: LoginWithKakaoUseCase,
 ): BaseViewModel<LoginState, LoginSideEffect>() {
 
     override val container = container<LoginState, LoginSideEffect>(LoginState())
@@ -30,7 +30,7 @@ class LoginViewModel @Inject constructor(
                     )
                 }
                 runCatching {
-                    loginUseCase.invoke().getOrThrow()
+                    loginWithKakaoUseCase.invoke().getOrThrow()
                 }.onSuccess {
                     postSideEffect(LoginSideEffect.NavToSignUp)
                 }.onFailure {


### PR DESCRIPTION
### 개요
* 로그인 API 연결

### 변경사항
- 로그인 API 연결
- 카카오 로그인 로직 변경
  - 카카오 로그인 성공 -> 서버 로그인 시도
- SignUpService -> LoginService
  - 로그인 회원가입 api 모두 있기 때문에 이름 변경
- AuthInterceptor -> LoginInterceptor
  - 로그인 회원가입 에만 쓰이므로 이름 변경
- AuthNetwork -> LoginNetwork
  - 로그인 회원가입 에만 쓰이므로 이름 변경

### 관련 지라 및 위키 링크
 - [ROFO-73](https://weit-2nd.atlassian.net/browse/ROFO-73) 


### 리뷰어에게 하고 싶은 말
* 나머진 이름 변경과 TODO 커밋이기 때문에 ae9a033f7b1a90699d3f37b34ffe66887a7e3b65 요거만 봐도 무방
* Auth 시리즈 -> Login 시리즈로 바뀐 이유
  * 로그인 회원가입 을 제외한 나머지 api 들은 인증 헤더에 서버의 accessToken을 사용하기 때문에 얘네들을 관리하는 애들을 Auth 머시기로 명명할 예정.
  * 원래 있던 애들은 로그인 회원가입에만 쓰이므로 Login으로 이름 변경함

[ROFO-73]: https://weit-2nd.atlassian.net/browse/ROFO-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ