### PR TITLE
ROFO-72 uri 유효성 확인

### DIFF
--- a/data/src/main/java/com/weit2nd/data/repository/signup/SignUpRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/signup/SignUpRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.weit2nd.data.model.user.SignUpRequest
 import com.weit2nd.data.source.localimage.LocalImageDatasource
 import com.weit2nd.data.source.signup.SignUpDataSource
 import com.weit2nd.data.util.getMultiPart
+import com.weit2nd.domain.exception.imageuri.NotImageException
 import com.weit2nd.domain.exception.user.SignUpException
 import com.weit2nd.domain.model.NicknameState
 import com.weit2nd.domain.repository.signup.SignUpRepository
@@ -27,6 +28,8 @@ class SignUpRepositoryImpl @Inject constructor(
         nickname: String,
         agreedTermIds: List<Long>,
     ) {
+        if (localImageDatasource.checkImageUriValid(image).not()) throw NotImageException()
+
         val imagePart = localImageDatasource.getImageMultipartBodyPart(
             uri = image,
             formDataName = "profileImage",

--- a/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.weit2nd.data.model.spot.ReportFoodSpotRequest
 import com.weit2nd.data.source.localimage.LocalImageDatasource
 import com.weit2nd.data.source.spot.FoodSpotDataSource
 import com.weit2nd.data.util.getMultiPart
+import com.weit2nd.domain.exception.imageuri.NotImageException
 import com.weit2nd.domain.model.spot.ReportFoodSpotState
 import com.weit2nd.domain.repository.spot.FoodSpotRepository
 import javax.inject.Inject
@@ -23,6 +24,8 @@ class FoodSpotRepositoryImpl @Inject constructor(
         closed: Boolean,
         images: List<String>,
     ) {
+        if (localImageDatasource.checkImagesUriValid(images).not()) throw NotImageException()
+
         val imageParts = images.map { image ->
             localImageDatasource.getImageMultipartBodyPart(
                 uri = image,
@@ -64,15 +67,19 @@ class FoodSpotRepositoryImpl @Inject constructor(
             invalidImage != null -> {
                 ReportFoodSpotState.InvalidImage(invalidImage)
             }
+
             verifyCoordinate(longitude, latitude).not() -> {
                 ReportFoodSpotState.BadCoordinate
             }
+
             images.size > MAX_IMAGE_COUNT -> {
                 ReportFoodSpotState.TooManyImages
             }
+
             verifyName(name).not() -> {
                 ReportFoodSpotState.BadFoodSpotName
             }
+
             else -> {
                 ReportFoodSpotState.Valid
             }

--- a/data/src/main/java/com/weit2nd/data/source/localimage/LocalImageDatasource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/localimage/LocalImageDatasource.kt
@@ -12,7 +12,7 @@ import com.weit2nd.data.model.LocalImageWithDirectory
 import com.weit2nd.data.util.getCompressedBytes
 import com.weit2nd.data.util.getRotatedBitmap
 import com.weit2nd.data.util.getScaledBitmap
-import com.weit2nd.domain.exception.imageuri.ImageUriException
+import com.weit2nd.domain.exception.imageuri.NotImageException
 import com.weit2nd.domain.model.localimage.LocalImage
 import java.io.FileNotFoundException
 import kotlinx.coroutines.Dispatchers
@@ -116,7 +116,7 @@ class LocalImageDatasource @Inject constructor(
     }
 
     private fun checkImageUriValid(uri: String) {
-        if (uri.isEmpty()) throw ImageUriException.EmptyUriException()
+        if (uri.isEmpty()) throw NotImageException()
         Uri.parse(uri).apply {
             checkReadableUri(this)
             checkImageType(this)
@@ -126,7 +126,7 @@ class LocalImageDatasource @Inject constructor(
     private fun checkReadableUri(uri: Uri) {
         contentResolver.openInputStream(uri).use { inputStream ->
             if (inputStream == null) {
-                throw FileNotFoundException("파일을 읽을 수 없습니다.")
+                throw FileNotFoundException()
             }
         }
     }
@@ -134,7 +134,7 @@ class LocalImageDatasource @Inject constructor(
     private fun checkImageType(uri: Uri) {
         val type = contentResolver.getType(uri)
         if ((type != null && type.startsWith("image/")).not()) {
-            throw ImageUriException.NotImageException()
+            throw NotImageException()
         }
     }
 

--- a/data/src/main/java/com/weit2nd/data/source/localimage/LocalImageDatasource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/localimage/LocalImageDatasource.kt
@@ -133,10 +133,7 @@ class LocalImageDatasource @Inject constructor(
     }
 
     fun checkImagesUriValid(images: List<String>): Boolean {
-        images.forEach { image ->
-            if (checkImageUriValid(image).not()) return false
-        }
-        return true
+        return images.all { image -> checkImageUriValid(image) }
     }
 
     fun checkImageUriValid(uri: String): Boolean {

--- a/domain/src/main/java/com/weit2nd/domain/exception/imageuri/ImageUriException.kt
+++ b/domain/src/main/java/com/weit2nd/domain/exception/imageuri/ImageUriException.kt
@@ -1,7 +1,3 @@
 package com.weit2nd.domain.exception.imageuri
 
-sealed class ImageUriException : Throwable() {
-
-    class EmptyUriException(override val message: String = "빈 uri값입니다.") : ImageUriException()
-    class NotImageException(override val message: String = "이미지가 아닙니다.") : ImageUriException()
-}
+class NotImageException : Throwable()

--- a/domain/src/main/java/com/weit2nd/domain/exception/imageuri/ImageUriException.kt
+++ b/domain/src/main/java/com/weit2nd/domain/exception/imageuri/ImageUriException.kt
@@ -1,0 +1,7 @@
+package com.weit2nd.domain.exception.imageuri
+
+sealed class ImageUriException : Throwable() {
+
+    class EmptyUriException(override val message: String = "빈 uri값입니다.") : ImageUriException()
+    class NotImageException(override val message: String = "이미지가 아닙니다.") : ImageUriException()
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
@@ -2,6 +2,7 @@ package com.weit2nd.presentation.ui.signup
 
 import androidx.core.net.toUri
 import androidx.lifecycle.viewModelScope
+import com.weit2nd.domain.exception.imageuri.NotImageException
 import com.weit2nd.domain.model.User
 import com.weit2nd.domain.usecase.pickimage.PickSingleImageUseCase
 import com.weit2nd.domain.usecase.signup.CheckNicknameDuplicateUseCase
@@ -65,7 +66,11 @@ class SignUpViewModel @Inject constructor(
                 }.onSuccess {
                     postSideEffect(SignUpSideEffect.NavToHome(User("으악")))
                 }.onFailure { throwable ->
-                    throwable.message?.let { postSideEffect(SignUpSideEffect.ShowToast(it)) }
+                    if (throwable is NotImageException) {
+                        postSideEffect(SignUpSideEffect.ShowToast("업로드된 파일이 이미지 형식이 아닙니다."))
+                    } else {
+                        throwable.message?.let { postSideEffect(SignUpSideEffect.ShowToast(it)) }
+                    }
                 }
             }
 


### PR DESCRIPTION
### 개요
- uri 유효성 확인
### 변경사항
- getFormattedImageBytes()에서 uri 유효성 확인

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-72) 

### 리뷰어에게 하고 싶은 말
- 세가지 경우로 예외를 던졌습니다. 
   1. uri값이 비어있는 경우 
   2. uri로 값을 읽어올 수 없는 경우 
   3. uri의 MIME 타입이 image가 아닌 경우
- 회원가입할 때 프로필사진을 설정하지 않을 수도 있는데, 그럴 경우에는 아예 image부분 멀티파트를 보내지 않으면 될 것 같습니다. 이것도 이번 pr에서 해결할까 하다가 나누는게 맞다고 생각해서 따로 이슈 파놓고 이번주 할일이 끝나면 해보겠습니다
