### PR TITLE
ROFO-69 로그인 회원가입 네비게이션 연결

### DIFF
--- a/data/src/main/java/com/weit2nd/data/di/SignUpModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/SignUpModule.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.Moshi
 import com.weit2nd.data.repository.signup.SignUpRepositoryImpl
 import com.weit2nd.data.service.CheckNicknameService
 import com.weit2nd.data.service.LoginService
+import com.weit2nd.data.source.auth.AuthDataSource
 import com.weit2nd.data.source.localimage.LocalImageDatasource
 import com.weit2nd.data.source.signup.SignUpDataSource
 import com.weit2nd.domain.repository.signup.SignUpRepository
@@ -22,11 +23,13 @@ object SignUpModule {
     @Provides
     fun providesSignUpRepository(
         signUpDataSource: SignUpDataSource,
+        authDataSource: AuthDataSource,
         localImageDatasource: LocalImageDatasource,
         moshi: Moshi,
     ): SignUpRepository {
         return SignUpRepositoryImpl(
             signUpDataSource = signUpDataSource,
+            authDataSource = authDataSource,
             localImageDatasource = localImageDatasource,
             moshi = moshi,
         )

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -30,6 +30,7 @@ import com.weit2nd.presentation.ui.select.place.SelectPlaceScreen
 import com.weit2nd.presentation.ui.select.place.map.SelectLocationMapScreen
 import com.weit2nd.presentation.ui.signup.SignUpScreen
 import com.weit2nd.presentation.ui.select.picture.SelectPictureScreen
+import com.weit2nd.presentation.ui.signup.terms.TermsScreen
 import com.weit2nd.presentation.ui.signup.terms.detail.TermDetailScreen
 import com.weit2nd.presentation.ui.splash.SplashScreen
 
@@ -48,6 +49,7 @@ fun AppNavHost(
     ) {
         splashComposable(navController)
         loginComposable(navController)
+        termsComposable(navController)
         signUpComposable(navController)
         homeComposable(navController)
         selectPictureComposable(navController)
@@ -93,12 +95,46 @@ private fun NavGraphBuilder.loginComposable(
                     }
                 }
             },
-            navToSignUp = {
-                navController.navigate(SignUpNavRoutes.GRAPH) {
+            navToTermAgreement = {
+                navController.navigate(TermsRoutes.GRAPH) {
                     popUpTo(LoginNavRoutes.GRAPH) {
                         inclusive = true
                     }
                 }
+            }
+        )
+    }
+}
+
+private fun NavGraphBuilder.termsComposable(
+    navController: NavHostController,
+) {
+    composable(route = TermsRoutes.GRAPH) {
+        TermsScreen(
+            navToSignUp = { ids ->
+                navController.navigate(SignUpNavRoutes.GRAPH) {
+                    popUpTo(TermsRoutes.GRAPH) {
+                        inclusive = true
+                    }
+                }
+            },
+            navToTermDetail = { id ->
+                navController.navigateToTermDetail(id)
+            }
+        )
+    }
+}
+
+private fun NavGraphBuilder.termDetailComposable(
+    navController: NavHostController,
+) {
+    composable(
+        "${TermDetailRoutes.GRAPH}/{${TermDetailRoutes.TERM_ID}}",
+        arguments = listOf(navArgument(TermDetailRoutes.TERM_ID) { type = NavType.LongType })
+    ) {
+        TermDetailScreen(
+            navToBack = {
+                navController.popBackStack()
             }
         )
     }
@@ -168,21 +204,6 @@ private fun NavGraphBuilder.selectLocationMapComposable(
     }
 }
 
-private fun NavGraphBuilder.termDetailComposable(
-    navController: NavHostController,
-) {
-    composable(
-        "${TermDetailRoutes.GRAPH}/{${TermDetailRoutes.TERM_ID}}",
-        arguments = listOf(navArgument(TermDetailRoutes.TERM_ID) { type = NavType.LongType })
-    ) {
-        TermDetailScreen(
-            navToBack = {
-                navController.popBackStack()
-            }
-        )
-    }
-}
-
 private fun NavGraphBuilder.imageViewerComposable(
     navController: NavHostController,
 ) {
@@ -238,6 +259,15 @@ object LoginNavRoutes {
     const val GRAPH = "login"
 }
 
+object TermsRoutes {
+    const val GRAPH = "terms"
+}
+
+object TermDetailRoutes {
+    const val GRAPH = "term_detail"
+    const val TERM_ID = "term_id"
+}
+
 object SignUpNavRoutes {
     const val GRAPH = "signup"
 }
@@ -253,11 +283,6 @@ object SelectPictureRoutes {
 
 object SelectLocationRoutes {
     const val GRAPH = "select_location"
-}
-
-object TermDetailRoutes {
-    const val GRAPH = "term_detail"
-    const val TERM_ID = "term_id"
 }
 
 object SelectLocationMapRoutes {

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -112,7 +112,7 @@ private fun NavGraphBuilder.termsComposable(
     composable(route = TermsRoutes.GRAPH) {
         TermsScreen(
             navToSignUp = { ids ->
-                navController.navigate(SignUpNavRoutes.GRAPH) {
+                navController.navigateToSignUp(ids) {
                     popUpTo(TermsRoutes.GRAPH) {
                         inclusive = true
                     }
@@ -143,7 +143,10 @@ private fun NavGraphBuilder.termDetailComposable(
 private fun NavGraphBuilder.signUpComposable(
     navController: NavHostController,
 ) {
-    composable(route = SignUpNavRoutes.GRAPH) {
+    composable(
+        route = "${SignUpNavRoutes.GRAPH}/{${SignUpNavRoutes.TERM_IDS}}",
+        arguments = listOf(navArgument(SignUpNavRoutes.TERM_IDS) { type = NavType.StringType })
+    ) {
         SignUpScreen(
             navToHome = { user ->
                 navController.navigateToHome(user) {
@@ -241,6 +244,14 @@ private fun NavHostController.navigateToTermDetail(
     navigate("${TermDetailRoutes.GRAPH}/$termId")
 }
 
+private fun NavHostController.navigateToSignUp(
+    termIds: List<Long>,
+    builder: NavOptionsBuilder.() -> Unit = {},
+) {
+    val ids = termIds.joinToString(",")
+    navigate("${SignUpNavRoutes.GRAPH}/$ids", builder)
+}
+
 private fun NavHostController.navigateToImageViewer(
     images: List<String> = listOf(),
     position: Int = 0,
@@ -270,6 +281,7 @@ object TermDetailRoutes {
 
 object SignUpNavRoutes {
     const val GRAPH = "signup"
+    const val TERM_IDS = "agreed_term_ids"
 }
 
 object HomeNavRoutes {

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -113,8 +113,8 @@ private fun NavGraphBuilder.termsComposable(
 ) {
     composable(route = TermsRoutes.GRAPH) {
         TermsScreen(
-            navToSignUp = { ids ->
-                navController.navigateToSignUp(ids) {
+            navToSignUp = { agreedTermIds ->
+                navController.navigateToSignUp(agreedTermIds) {
                     popUpTo(TermsRoutes.GRAPH) {
                         inclusive = true
                     }
@@ -247,11 +247,11 @@ private fun NavHostController.navigateToTermDetail(
 }
 
 private fun NavHostController.navigateToSignUp(
-    termIds: List<Long>,
+    agreedTermIds: List<Long>,
     builder: NavOptionsBuilder.() -> Unit = {},
 ) {
-    val termIdsJson = Uri.encode(Gson().toJson(termIds.toTermIdsDTO()))
-    navigate("${SignUpNavRoutes.GRAPH}/$termIdsJson", builder)
+    val agreedTermIdsJson = Uri.encode(Gson().toJson(agreedTermIds.toTermIdsDTO()))
+    navigate("${SignUpNavRoutes.GRAPH}/$agreedTermIdsJson", builder)
 }
 
 private fun NavHostController.navigateToImageViewer(

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -18,10 +18,12 @@ import com.weit2nd.domain.model.Coordinate
 import com.weit2nd.domain.model.User
 import com.weit2nd.presentation.navigation.dto.toCoordinateDTO
 import com.weit2nd.presentation.navigation.dto.toImageViewerDTO
+import com.weit2nd.presentation.navigation.dto.toTermIdsDTO
 import com.weit2nd.presentation.navigation.type.UserType
 import com.weit2nd.presentation.navigation.dto.toUserDTO
 import com.weit2nd.presentation.navigation.type.CoordinateType
 import com.weit2nd.presentation.navigation.type.ImageViewerDataType
+import com.weit2nd.presentation.navigation.type.TermIdsType
 import com.weit2nd.presentation.ui.common.imageviewer.ImageViewerData
 import com.weit2nd.presentation.ui.common.imageviewer.ImageViewerScreen
 import com.weit2nd.presentation.ui.home.HomeScreen
@@ -145,7 +147,7 @@ private fun NavGraphBuilder.signUpComposable(
 ) {
     composable(
         route = "${SignUpNavRoutes.GRAPH}/{${SignUpNavRoutes.TERM_IDS}}",
-        arguments = listOf(navArgument(SignUpNavRoutes.TERM_IDS) { type = NavType.StringType })
+        arguments = listOf(navArgument(SignUpNavRoutes.TERM_IDS) { type = TermIdsType() })
     ) {
         SignUpScreen(
             navToHome = { user ->
@@ -248,8 +250,8 @@ private fun NavHostController.navigateToSignUp(
     termIds: List<Long>,
     builder: NavOptionsBuilder.() -> Unit = {},
 ) {
-    val ids = termIds.joinToString(",")
-    navigate("${SignUpNavRoutes.GRAPH}/$ids", builder)
+    val termIdsJson = Uri.encode(Gson().toJson(termIds.toTermIdsDTO()))
+    navigate("${SignUpNavRoutes.GRAPH}/$termIdsJson", builder)
 }
 
 private fun NavHostController.navigateToImageViewer(

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/TermIdsDTO.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/TermIdsDTO.kt
@@ -1,0 +1,13 @@
+package com.weit2nd.presentation.navigation.dto
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class TermIdsDTO(
+    val ids: List<Long>,
+) : Parcelable
+
+fun TermIdsDTO.toTermIds(): List<Long> = ids
+
+fun List<Long>.toTermIdsDTO(): TermIdsDTO = TermIdsDTO(this)

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/type/TermIdsType.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/type/TermIdsType.kt
@@ -1,0 +1,25 @@
+package com.weit2nd.presentation.navigation.type
+
+import android.os.Build
+import android.os.Bundle
+import androidx.navigation.NavType
+import com.google.gson.Gson
+import com.weit2nd.presentation.navigation.dto.TermIdsDTO
+
+class TermIdsType : NavType<TermIdsDTO>(isNullableAllowed = false) {
+    override fun get(bundle: Bundle, key: String): TermIdsDTO? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            bundle.getParcelable(key, TermIdsDTO::class.java)
+        } else {
+            bundle.getParcelable(key)
+        }
+    }
+
+    override fun parseValue(value: String): TermIdsDTO {
+        return Gson().fromJson(value, TermIdsDTO::class.java)
+    }
+
+    override fun put(bundle: Bundle, key: String, value: TermIdsDTO) {
+        bundle.putParcelable(key, value)
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/login/LoginScreen.kt
@@ -20,7 +20,7 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 fun LoginScreen(
     vm: LoginViewModel = hiltViewModel(),
     navToHome: (User) -> Unit,
-    navToSignUp: () -> Unit,
+    navToTermAgreement: () -> Unit,
 ) {
     val state = vm.collectAsState()
     vm.collectSideEffect { sideEffect ->
@@ -29,8 +29,8 @@ fun LoginScreen(
                 navToHome(sideEffect.user)
             }
 
-            is LoginSideEffect.NavToSignUp -> {
-                navToSignUp()
+            is LoginSideEffect.NavToTermAgreement -> {
+                navToTermAgreement()
             }
         }
     }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/login/LoginSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/login/LoginSideEffect.kt
@@ -8,5 +8,5 @@ sealed class LoginSideEffect {
         val user: User,
     ) : LoginSideEffect()
 
-    data object NavToSignUp : LoginSideEffect()
+    data object NavToTermAgreement : LoginSideEffect()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/login/LoginViewModel.kt
@@ -36,7 +36,7 @@ class LoginViewModel @Inject constructor(
                     .onSuccess { postSideEffect(LoginSideEffect.NavToHome(User("test"))) }
                     .onFailure { throwable ->
                         if (throwable is LoginException.UserNotFoundException) {
-                            postSideEffect(LoginSideEffect.NavToSignUp)
+                            postSideEffect(LoginSideEffect.NavToTermAgreement)
                         } else {
                             Log.e("LoginError", "$throwable")
                             reduce {

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/login/LoginViewModel.kt
@@ -1,6 +1,8 @@
 package com.weit2nd.presentation.ui.login
 
 import android.util.Log
+import com.weit2nd.domain.exception.user.LoginException
+import com.weit2nd.domain.model.User
 import com.weit2nd.domain.usecase.login.LoginWithKakaoUseCase
 import com.weit2nd.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,7 +15,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val loginWithKakaoUseCase: LoginWithKakaoUseCase,
-): BaseViewModel<LoginState, LoginSideEffect>() {
+) : BaseViewModel<LoginState, LoginSideEffect>() {
 
     override val container = container<LoginState, LoginSideEffect>(LoginState())
 
@@ -29,21 +31,21 @@ class LoginViewModel @Inject constructor(
                         isLoading = true,
                     )
                 }
-                // TODO 로그인 UseCase는 Result로 반환되므로 runCatching 제거
-                // TODO 로그인 성공시 메인 화면으로 이동
-                // TODO UserNotFoundException이면 회원가입으로 이동
-                runCatching {
-                    loginWithKakaoUseCase.invoke().getOrThrow()
-                }.onSuccess {
-                    postSideEffect(LoginSideEffect.NavToSignUp)
-                }.onFailure {
-                    Log.e("MainTest", "$it")
-                    reduce {
-                        state.copy(
-                            isLoading = false,
-                        )
+
+                loginWithKakaoUseCase.invoke()
+                    .onSuccess { postSideEffect(LoginSideEffect.NavToHome(User("test"))) }
+                    .onFailure { throwable ->
+                        if (throwable is LoginException.UserNotFoundException) {
+                            postSideEffect(LoginSideEffect.NavToSignUp)
+                        } else {
+                            Log.e("LoginError", "$throwable")
+                            reduce {
+                                state.copy(
+                                    isLoading = false,
+                                )
+                            }
+                        }
                     }
-                }
             }
         }
     }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/map/MapViewModel.kt
@@ -54,13 +54,13 @@ class MapViewModel @Inject constructor(
                 postSideEffect(
                     MapSideEffect.RefreshMarkers(
                         map,
-                        container.stateFlow.value.restaurants
+                        state.restaurants
                     )
                 )
             }
 
             is MapIntent.RequestCameraMove -> {
-                container.stateFlow.value.map?.let { map ->
+                state.map?.let { map ->
                     postSideEffect(MapSideEffect.MoveCamera(map, position))
                 }
             }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/SelectPlaceViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/SelectPlaceViewModel.kt
@@ -37,7 +37,7 @@ class SelectPlaceViewModel @Inject constructor(
             SelectPlaceIntent.SearchPlace -> {
                 runCatching {
                     val result =
-                        searchPlacesWithWordUseCase(searchWord = container.stateFlow.value.userInput)
+                        searchPlacesWithWordUseCase(searchWord = state.userInput)
                     reduce {
                         state.copy(
                             searchResults = result

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectLocationMapViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectLocationMapViewModel.kt
@@ -112,7 +112,7 @@ class SelectLocationMapViewModel @Inject constructor(
             }
 
             is SelectLocationMapIntent.RequestCameraMove -> {
-                container.stateFlow.value.map?.let { map ->
+                state.map?.let { map ->
                     postSideEffect(SelectLocationMapSideEffect.MoveCamera(map, position))
                 }
             }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpState.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import com.weit2nd.domain.model.NicknameState
 
 data class SignUpState(
-    val agreedTermIds: List<Long> = emptyList(),
     val profileImageUri: Uri? = null,
     val nickname: String = "",
     val isLoading: Boolean = false,

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpState.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import com.weit2nd.domain.model.NicknameState
 
 data class SignUpState(
+    val agreedTermIds: List<Long> = emptyList(),
     val profileImageUri: Uri? = null,
     val nickname: String = "",
     val isLoading: Boolean = false,

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
@@ -11,6 +11,8 @@ import com.weit2nd.domain.usecase.signup.SignUpUseCase
 import com.weit2nd.domain.usecase.signup.VerifyNicknameUseCase
 import com.weit2nd.presentation.base.BaseViewModel
 import com.weit2nd.presentation.navigation.SignUpNavRoutes
+import com.weit2nd.presentation.navigation.dto.TermIdsDTO
+import com.weit2nd.presentation.navigation.dto.toTermIds
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -30,8 +32,10 @@ class SignUpViewModel @Inject constructor(
 ) : BaseViewModel<SignUpState, SignUpSideEffect>() {
 
     private val agreedTermIds by lazy {
-        savedStateHandle.get<String>(SignUpNavRoutes.TERM_IDS)
-            ?.split(",")?.map { it.toLong() } ?: emptyList()
+        checkNotNull(
+            savedStateHandle.get<TermIdsDTO>(SignUpNavRoutes.TERM_IDS)
+                ?.toTermIds()
+        )
     }
     override val container = container<SignUpState, SignUpSideEffect>(
         SignUpState(agreedTermIds = agreedTermIds)

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
@@ -37,9 +37,7 @@ class SignUpViewModel @Inject constructor(
                 ?.toTermIds()
         )
     }
-    override val container = container<SignUpState, SignUpSideEffect>(
-        SignUpState(agreedTermIds = agreedTermIds)
-    )
+    override val container = container<SignUpState, SignUpSideEffect>(SignUpState())
     private var nicknameDuplicateCheckJob: Job = Job().apply { complete() }
 
     fun onSignUpButtonClick() {

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
@@ -67,7 +67,7 @@ class SignUpViewModel @Inject constructor(
         when (this@post) {
             SignUpIntent.RequestSignUp -> {
                 runCatching {
-                    container.stateFlow.value.apply {
+                    state.apply {
                         signUpUseCase.invoke(
                             image = (profileImageUri ?: "").toString(),
                             nickname = nickname,

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/terms/TermsIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/terms/TermsIntent.kt
@@ -10,4 +10,5 @@ sealed class TermsIntent {
     data object UpdateAllAgreementWithTermAgreements : TermsIntent()
     data object VerifyTermAgreements : TermsIntent()
     data class NavToTermDetail(val termId: Long) : TermsIntent()
+    data object NavToSignUp : TermsIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/terms/TermsScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/terms/TermsScreen.kt
@@ -42,6 +42,10 @@ fun TermsScreen(
             is TermsSideEffect.NavToTermDetail -> {
                 navToTermDetail(sideEffect.termId)
             }
+
+            is TermsSideEffect.NavToSignUp -> {
+                navToSignUp(sideEffect.termIds)
+            }
         }
     }
 
@@ -87,7 +91,7 @@ fun TermsScreen(
         Button(
             modifier = Modifier.fillMaxWidth(),
             enabled = state.value.canProceed,
-            onClick = { }, // 다음 화면으로 이동
+            onClick = vm::onSignUpBtnClicked,
         ) {
             Text(text = "다음")
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/terms/TermsScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/terms/TermsScreen.kt
@@ -32,13 +32,15 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
 fun TermsScreen(
-    vm: TermsViewModel = hiltViewModel()
+    vm: TermsViewModel = hiltViewModel(),
+    navToSignUp: (termIds: List<Long>) -> Unit,
+    navToTermDetail: (Long) -> Unit,
 ) {
     val state = vm.collectAsState()
     vm.collectSideEffect { sideEffect ->
         when (sideEffect) {
             is TermsSideEffect.NavToTermDetail -> {
-                // TODO: 약관 상세 화면으로 이동
+                navToTermDetail(sideEffect.termId)
             }
         }
     }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/terms/TermsSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/terms/TermsSideEffect.kt
@@ -3,4 +3,5 @@ package com.weit2nd.presentation.ui.signup.terms
 sealed class TermsSideEffect {
 
     data class NavToTermDetail(val termId: Long) : TermsSideEffect()
+    data class NavToSignUp(val termIds: List<Long>) : TermsSideEffect()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/terms/TermsViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/terms/TermsViewModel.kt
@@ -36,6 +36,10 @@ class TermsViewModel @Inject constructor(
         TermsIntent.NavToTermDetail(termId).post()
     }
 
+    fun onSignUpBtnClicked() {
+        TermsIntent.NavToSignUp.post()
+    }
+
     private fun TermsIntent.post() = intent {
         when (this@post) {
             TermsIntent.GetTerms -> {
@@ -98,6 +102,12 @@ class TermsViewModel @Inject constructor(
 
             is TermsIntent.NavToTermDetail -> {
                 postSideEffect(TermsSideEffect.NavToTermDetail(termId))
+            }
+
+            TermsIntent.NavToSignUp -> {
+                val agreedTermIds = container.stateFlow.value.termStatuses.filter { it.isChecked }
+                    .map { it.term.id }
+                postSideEffect(TermsSideEffect.NavToSignUp(agreedTermIds))
             }
         }
     }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/terms/TermsViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/terms/TermsViewModel.kt
@@ -54,7 +54,7 @@ class TermsViewModel @Inject constructor(
             is TermsIntent.SetAllAgreement -> {
                 reduce {
                     state.copy(
-                        termStatuses = container.stateFlow.value.termStatuses.map {
+                        termStatuses = state.termStatuses.map {
                             it.copy(isChecked = isChecked)
                         },
                         agreeAll = isChecked
@@ -65,7 +65,7 @@ class TermsViewModel @Inject constructor(
             is TermsIntent.SetTermAgreement -> {
                 reduce {
                     state.copy(
-                        termStatuses = container.stateFlow.value.termStatuses.map {
+                        termStatuses = state.termStatuses.map {
                             if (it.term == term) it.copy(isChecked = isChecked) else it
                         }
                     )
@@ -73,7 +73,7 @@ class TermsViewModel @Inject constructor(
             }
 
             TermsIntent.UpdateAllAgreementWithTermAgreements -> {
-                if (container.stateFlow.value.termStatuses.all { it.isChecked }) {
+                if (state.termStatuses.all { it.isChecked }) {
                     reduce {
                         state.copy(
                             agreeAll = true
@@ -89,7 +89,7 @@ class TermsViewModel @Inject constructor(
             }
 
             TermsIntent.VerifyTermAgreements -> {
-                val canProceed = container.stateFlow.value.termStatuses
+                val canProceed = state.termStatuses
                     .filter { it.term.isRequired }
                     .all { it.isChecked }
 
@@ -105,7 +105,7 @@ class TermsViewModel @Inject constructor(
             }
 
             TermsIntent.NavToSignUp -> {
-                val agreedTermIds = container.stateFlow.value.termStatuses.filter { it.isChecked }
+                val agreedTermIds = state.termStatuses.filter { it.isChecked }
                     .map { it.term.id }
                 postSideEffect(TermsSideEffect.NavToSignUp(agreedTermIds))
             }


### PR DESCRIPTION
### 개요
로그인 화면에서 가입 되어있으면 메인 화면,
가입이 안되어있으면 → 약관 동의 → 회원 가입 → 메인 화면 으로 이동
### 변경사항
- 로그인 회원가입 네비게이션 연결

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-69) 

### 리뷰어에게 하고 싶은 말
- 약관화면에서 회원가입 화면으로 이동할 때, 동의한 약관 id들(`List<Long>`)을 보내줘야 했는데, 이것만을 위해서 DTO를 만드는 것은 너무 과하다고 생각해서 ","로 나눈 String으로 바꿔서 보내주었습니다.
