### PR TITLE
ROFO-98 스플래쉬 로그인 오류 수정

### DIFF
--- a/data/src/main/java/com/weit2nd/data/interceptor/LoginInterceptor.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/LoginInterceptor.kt
@@ -5,29 +5,34 @@ import okhttp3.Interceptor
 import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.internal.http.HTTP_UNAUTHORIZED
 import javax.inject.Inject
 
 class LoginInterceptor @Inject constructor(
     private val dataSource: AuthDataSource,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val socialAccessToken = runCatching {
+        return runCatching {
             dataSource.getSocialAccessToken()
-        }.getOrElse {
-            return Response.Builder()
-                .request(chain.request())
-                .protocol(Protocol.HTTP_1_1)
-                .code(401)
-                .message("${it.message}")
-                .body(it.stackTraceToString().toResponseBody())
-                .build()
-        }
-        val authorization = BEARER_PREFIX + socialAccessToken
-        val newRequest =
-            chain.request().newBuilder().apply {
-                addHeader(AUTHORIZATION_HEADER, authorization)
+        }.fold(
+            onSuccess = { socialAccessToken ->
+                val authorization = BEARER_PREFIX + socialAccessToken
+                val newRequest =
+                    chain.request().newBuilder().apply {
+                        addHeader(AUTHORIZATION_HEADER, authorization)
+                    }
+                chain.proceed(newRequest.build())
+            },
+            onFailure = {
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(HTTP_UNAUTHORIZED)
+                    .message("${it.message}")
+                    .body(it.stackTraceToString().toResponseBody())
+                    .build()
             }
-        return chain.proceed(newRequest.build())
+        )
     }
 
     companion object {

--- a/data/src/main/java/com/weit2nd/data/interceptor/LoginInterceptor.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/LoginInterceptor.kt
@@ -2,14 +2,27 @@ package com.weit2nd.data.interceptor
 
 import com.weit2nd.data.source.auth.AuthDataSource
 import okhttp3.Interceptor
+import okhttp3.Protocol
 import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 import javax.inject.Inject
 
 class LoginInterceptor @Inject constructor(
     private val dataSource: AuthDataSource,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val authorization = BEARER_PREFIX + dataSource.getSocialAccessToken()
+        val socialAccessToken = runCatching {
+            dataSource.getSocialAccessToken()
+        }.getOrElse {
+            return Response.Builder()
+                .request(chain.request())
+                .protocol(Protocol.HTTP_1_1)
+                .code(401)
+                .message("${it.message}")
+                .body(it.stackTraceToString().toResponseBody())
+                .build()
+        }
+        val authorization = BEARER_PREFIX + socialAccessToken
         val newRequest =
             chain.request().newBuilder().apply {
                 addHeader(AUTHORIZATION_HEADER, authorization)


### PR DESCRIPTION
### 개요
- AuthDataSource에서 throw한 예외를 interceptor에서 처리
### 변경사항
- 예외 발생하면 401 Response를 반환

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-98) 

### 리뷰어에게 하고 싶은 말
- body를 무조건 넣어줘야해서 뭐넣을까 하다가 stackTraceToString 넣었는데 괜찮을까요