### PR TITLE
ROFO-90 로그아웃, 회원탈퇴 API 연결

### DIFF
--- a/data/src/main/java/com/weit2nd/data/di/AuthModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/AuthModule.kt
@@ -2,7 +2,7 @@ package com.weit2nd.data.di
 
 import com.weit2nd.data.interceptor.AuthInterceptor
 import com.weit2nd.data.interceptor.LoginInterceptor
-import com.weit2nd.data.source.auth.AuthDataSource
+import com.weit2nd.data.source.token.TokenDataSource
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -14,19 +14,19 @@ import javax.inject.Singleton
 object AuthModule {
     @Singleton
     @Provides
-    fun providesLoginInterceptor(dataSource: AuthDataSource): LoginInterceptor {
+    fun providesLoginInterceptor(dataSource: TokenDataSource): LoginInterceptor {
         return LoginInterceptor(dataSource)
     }
 
     @Singleton
     @Provides
-    fun providesAuthInterceptor(dataSource: AuthDataSource): AuthInterceptor {
+    fun providesAuthInterceptor(dataSource: TokenDataSource): AuthInterceptor {
         return AuthInterceptor(dataSource)
     }
 
     @Singleton
     @Provides
-    fun providesAuthDataSource(): AuthDataSource {
-        return AuthDataSource()
+    fun providesTokenDataSource(): TokenDataSource {
+        return TokenDataSource()
     }
 }

--- a/data/src/main/java/com/weit2nd/data/di/LoginModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/LoginModule.kt
@@ -2,7 +2,7 @@ package com.weit2nd.data.di
 
 import com.weit2nd.data.repository.login.LoginRepositoryImpl
 import com.weit2nd.data.service.LoginService
-import com.weit2nd.data.source.auth.AuthDataSource
+import com.weit2nd.data.source.token.TokenDataSource
 import com.weit2nd.data.source.login.LoginDataSource
 import com.weit2nd.data.util.ActivityProvider
 import com.weit2nd.domain.repository.login.LoginRepository
@@ -20,12 +20,12 @@ object LoginModule {
     @Provides
     fun providesLoginRepository(
         loginDataSource: LoginDataSource,
-        authDataSource: AuthDataSource,
+        tokenDataSource: TokenDataSource,
         activityProvider: ActivityProvider,
     ): LoginRepository {
         return LoginRepositoryImpl(
             loginDataSource = loginDataSource,
-            authDataSource = authDataSource,
+            tokenDataSource = tokenDataSource,
             activityProvider = activityProvider,
         )
     }

--- a/data/src/main/java/com/weit2nd/data/di/LogoutModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/LogoutModule.kt
@@ -1,0 +1,40 @@
+package com.weit2nd.data.di
+
+import com.weit2nd.data.repository.logout.LogoutRepositoryImpl
+import com.weit2nd.data.service.LogoutService
+import com.weit2nd.data.source.logout.LogoutDataSource
+import com.weit2nd.domain.repository.logout.LogoutRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+import retrofit2.Retrofit
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object LogoutModule {
+    @ViewModelScoped
+    @Provides
+    fun providesLogoutRepository(logoutDataSource: LogoutDataSource): LogoutRepository {
+        return LogoutRepositoryImpl(
+            logoutDataSource = logoutDataSource,
+        )
+    }
+
+    @ViewModelScoped
+    @Provides
+    fun providesLogoutDataSource(service: LogoutService): LogoutDataSource {
+        return LogoutDataSource(
+            service = service,
+        )
+    }
+
+    @ViewModelScoped
+    @Provides
+    fun providesLogoutService(
+        @AuthNetwork retrofit: Retrofit,
+    ): LogoutService {
+        return retrofit.create(LogoutService::class.java)
+    }
+}

--- a/data/src/main/java/com/weit2nd/data/di/SignUpModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/SignUpModule.kt
@@ -4,9 +4,9 @@ import com.squareup.moshi.Moshi
 import com.weit2nd.data.repository.signup.SignUpRepositoryImpl
 import com.weit2nd.data.service.CheckNicknameService
 import com.weit2nd.data.service.LoginService
-import com.weit2nd.data.source.auth.AuthDataSource
 import com.weit2nd.data.source.localimage.LocalImageDatasource
 import com.weit2nd.data.source.signup.SignUpDataSource
+import com.weit2nd.data.source.token.TokenDataSource
 import com.weit2nd.domain.repository.signup.SignUpRepository
 import dagger.Module
 import dagger.Provides
@@ -22,13 +22,13 @@ object SignUpModule {
     @Provides
     fun providesSignUpRepository(
         signUpDataSource: SignUpDataSource,
-        authDataSource: AuthDataSource,
+        tokenDataSource: TokenDataSource,
         localImageDatasource: LocalImageDatasource,
         moshi: Moshi,
     ): SignUpRepository {
         return SignUpRepositoryImpl(
             signUpDataSource = signUpDataSource,
-            authDataSource = authDataSource,
+            tokenDataSource = tokenDataSource,
             localImageDatasource = localImageDatasource,
             moshi = moshi,
         )

--- a/data/src/main/java/com/weit2nd/data/interceptor/AuthInterceptor.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/AuthInterceptor.kt
@@ -1,12 +1,12 @@
 package com.weit2nd.data.interceptor
 
-import com.weit2nd.data.source.auth.AuthDataSource
+import com.weit2nd.data.source.token.TokenDataSource
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
 class AuthInterceptor @Inject constructor(
-    private val dataSource: AuthDataSource,
+    private val dataSource: TokenDataSource,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         // TODO 만료된 액세스 토큰 갱신 로직 추가

--- a/data/src/main/java/com/weit2nd/data/interceptor/LoginInterceptor.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/LoginInterceptor.kt
@@ -1,6 +1,6 @@
 package com.weit2nd.data.interceptor
 
-import com.weit2nd.data.source.auth.AuthDataSource
+import com.weit2nd.data.source.token.TokenDataSource
 import okhttp3.Interceptor
 import okhttp3.Protocol
 import okhttp3.Response
@@ -9,7 +9,7 @@ import okhttp3.internal.http.HTTP_UNAUTHORIZED
 import javax.inject.Inject
 
 class LoginInterceptor @Inject constructor(
-    private val dataSource: AuthDataSource,
+    private val dataSource: TokenDataSource,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         return runCatching {

--- a/data/src/main/java/com/weit2nd/data/repository/login/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/login/LoginRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.weit2nd.data.repository.login
 
 import com.kakao.sdk.user.UserApiClient
-import com.weit2nd.data.source.auth.AuthDataSource
+import com.weit2nd.data.source.token.TokenDataSource
 import com.weit2nd.data.source.login.LoginDataSource
 import com.weit2nd.data.util.ActivityProvider
 import com.weit2nd.domain.exception.UnknownException
@@ -16,7 +16,7 @@ import javax.inject.Inject
 
 class LoginRepositoryImpl @Inject constructor(
     private val loginDataSource: LoginDataSource,
-    private val authDataSource: AuthDataSource,
+    private val tokenDataSource: TokenDataSource,
     private val activityProvider: ActivityProvider,
 ) : LoginRepository {
     override suspend fun loginWithKakao(): Result<Unit> =
@@ -46,8 +46,8 @@ class LoginRepositoryImpl @Inject constructor(
             }
         return if (serverLoginResult.isSuccess) {
             val token = serverLoginResult.getOrThrow()
-            authDataSource.setAccessToken(token.accessToken)
-            authDataSource.setRefreshToken(token.refreshToken)
+            tokenDataSource.setAccessToken(token.accessToken)
+            tokenDataSource.setRefreshToken(token.refreshToken)
             Result.success(Unit)
         } else {
             val throwable = serverLoginResult.exceptionOrNull() ?: UnknownException()

--- a/data/src/main/java/com/weit2nd/data/repository/logout/LogoutRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/logout/LogoutRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.weit2nd.data.repository.logout
+
+import com.weit2nd.data.source.logout.LogoutDataSource
+import com.weit2nd.domain.repository.logout.LogoutRepository
+import javax.inject.Inject
+
+class LogoutRepositoryImpl @Inject constructor(
+    private val logoutDataSource: LogoutDataSource,
+) : LogoutRepository {
+    override suspend fun logout() {
+        logoutDataSource.logout()
+        // TODO 인증 토큰 제거
+    }
+
+    override suspend fun withdraw() {
+        logoutDataSource.withdraw()
+        // TODO 인증 토큰 제거
+    }
+}

--- a/data/src/main/java/com/weit2nd/data/repository/logout/LogoutRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/logout/LogoutRepositoryImpl.kt
@@ -9,11 +9,13 @@ class LogoutRepositoryImpl @Inject constructor(
 ) : LogoutRepository {
     override suspend fun logout() {
         logoutDataSource.logout()
+        logoutDataSource.logoutToKakao()
         // TODO 인증 토큰 제거
     }
 
     override suspend fun withdraw() {
         logoutDataSource.withdraw()
+        logoutDataSource.logoutToKakao()
         // TODO 인증 토큰 제거
     }
 }

--- a/data/src/main/java/com/weit2nd/data/repository/signup/SignUpRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/signup/SignUpRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.weit2nd.data.repository.signup
 
 import com.squareup.moshi.Moshi
 import com.weit2nd.data.model.user.SignUpRequest
-import com.weit2nd.data.source.auth.AuthDataSource
+import com.weit2nd.data.source.token.TokenDataSource
 import com.weit2nd.data.source.localimage.LocalImageDatasource
 import com.weit2nd.data.source.signup.SignUpDataSource
 import com.weit2nd.data.util.getMultiPart
@@ -18,7 +18,7 @@ import javax.inject.Inject
 
 class SignUpRepositoryImpl @Inject constructor(
     private val signUpDataSource: SignUpDataSource,
-    private val authDataSource: AuthDataSource,
+    private val tokenDataSource: TokenDataSource,
     private val localImageDatasource: LocalImageDatasource,
     private val moshi: Moshi,
 ) : SignUpRepository {
@@ -54,8 +54,8 @@ class SignUpRepositoryImpl @Inject constructor(
                 signUpRequest = signUpPart,
             )
         }.onSuccess { token ->
-            authDataSource.setAccessToken(token.accessToken)
-            authDataSource.setRefreshToken(token.refreshToken)
+            tokenDataSource.setAccessToken(token.accessToken)
+            tokenDataSource.setRefreshToken(token.refreshToken)
         }.onFailure {
             throwSignUpException(it)
         }

--- a/data/src/main/java/com/weit2nd/data/service/LogoutService.kt
+++ b/data/src/main/java/com/weit2nd/data/service/LogoutService.kt
@@ -1,0 +1,11 @@
+package com.weit2nd.data.service
+
+import retrofit2.http.POST
+
+interface LogoutService {
+    @POST("/api/v1/auth/sign-out")
+    suspend fun logout()
+
+    @POST("/api/v1/auth/withdraw")
+    suspend fun withdraw()
+}

--- a/data/src/main/java/com/weit2nd/data/source/logout/LogoutDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/logout/LogoutDataSource.kt
@@ -1,6 +1,10 @@
 package com.weit2nd.data.source.logout
 
+import com.kakao.sdk.user.UserApiClient
 import com.weit2nd.data.service.LogoutService
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class LogoutDataSource @Inject constructor(
@@ -13,4 +17,14 @@ class LogoutDataSource @Inject constructor(
     suspend fun withdraw() {
         service.withdraw()
     }
+
+    // 성공이냐 실패냐는 크게 중요하지 않지만 결과가 나올때 까지는 기다려야 하기 때문에
+    // logout 콜백에서 값을 넘길 때 까지 기다림
+    suspend fun logoutToKakao() =
+        callbackFlow {
+            UserApiClient.instance.logout {
+                trySend(Unit)
+            }
+            awaitClose { }
+        }.first()
 }

--- a/data/src/main/java/com/weit2nd/data/source/logout/LogoutDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/logout/LogoutDataSource.kt
@@ -1,0 +1,16 @@
+package com.weit2nd.data.source.logout
+
+import com.weit2nd.data.service.LogoutService
+import javax.inject.Inject
+
+class LogoutDataSource @Inject constructor(
+    private val service: LogoutService,
+) {
+    suspend fun logout() {
+        service.logout()
+    }
+
+    suspend fun withdraw() {
+        service.withdraw()
+    }
+}

--- a/data/src/main/java/com/weit2nd/data/source/token/TokenDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/token/TokenDataSource.kt
@@ -1,9 +1,9 @@
-package com.weit2nd.data.source.auth
+package com.weit2nd.data.source.token
 
 import com.kakao.sdk.auth.AuthApiClient
 import com.weit2nd.domain.exception.auth.AuthException
 
-class AuthDataSource {
+class TokenDataSource {
     // TODO 토큰 보관 로적 추가 예정. 이렇게 저장해서 쓰면 안됨
     private var accessToken = ""
     private var refreshToken = ""

--- a/domain/src/main/java/com/weit2nd/domain/repository/logout/LogoutRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/logout/LogoutRepository.kt
@@ -1,0 +1,7 @@
+package com.weit2nd.domain.repository.logout
+
+interface LogoutRepository {
+    suspend fun logout()
+
+    suspend fun withdraw()
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/logout/LogoutUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/logout/LogoutUseCase.kt
@@ -1,0 +1,12 @@
+package com.weit2nd.domain.usecase.logout
+
+import com.weit2nd.domain.repository.logout.LogoutRepository
+import javax.inject.Inject
+
+class LogoutUseCase @Inject constructor(
+    private val repository: LogoutRepository,
+) {
+    suspend operator fun invoke() {
+        repository.logout()
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/logout/WithdrawUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/logout/WithdrawUseCase.kt
@@ -1,0 +1,12 @@
+package com.weit2nd.domain.usecase.logout
+
+import com.weit2nd.domain.repository.logout.LogoutRepository
+import javax.inject.Inject
+
+class WithdrawUseCase @Inject constructor(
+    private val repository: LogoutRepository,
+) {
+    suspend operator fun invoke() {
+        repository.withdraw()
+    }
+}


### PR DESCRIPTION
### 개요
- 로그아웃, 회원탈퇴 API 연결

### 변경사항
- 로그아웃, 회원탈퇴 API 연결
- AuthDataSource -> TokenDataSource
  - 생각해보니 토큰만 관리하게될 예정이라 이름도 토큰으로 바꿈

### 관련 지라 및 위키 링크
 - [ROFO-90](https://weit-2nd.atlassian.net/browse/ROFO-90) 

### 리뷰어에게 하고 싶은 말
- 테스트 하다가 발견했는데 회원가입 버튼에는 로딩 동작이 빠져있네용

[ROFO-90]: https://weit-2nd.atlassian.net/browse/ROFO-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ