### PR TITLE
ROFO-85 토큰 자동 갱신 기능

### DIFF
--- a/data/src/main/java/com/weit2nd/data/di/AuthModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/AuthModule.kt
@@ -1,5 +1,6 @@
 package com.weit2nd.data.di
 
+import com.weit2nd.data.interceptor.AuthAuthenticator
 import com.weit2nd.data.interceptor.AuthInterceptor
 import com.weit2nd.data.interceptor.LoginInterceptor
 import com.weit2nd.data.service.RefreshTokenService
@@ -24,6 +25,12 @@ object AuthModule {
     @Provides
     fun providesAuthInterceptor(dataSource: TokenDataSource): AuthInterceptor {
         return AuthInterceptor(dataSource)
+    }
+
+    @Singleton
+    @Provides
+    fun providesAuthAuthenticator(dataSource: TokenDataSource): AuthAuthenticator {
+        return AuthAuthenticator(dataSource)
     }
 
     @Singleton

--- a/data/src/main/java/com/weit2nd/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/weit2nd/data/di/NetworkModule.kt
@@ -5,6 +5,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.weit2nd.data.BuildConfig
 import com.weit2nd.data.R
+import com.weit2nd.data.interceptor.AuthAuthenticator
 import com.weit2nd.data.interceptor.AuthInterceptor
 import com.weit2nd.data.interceptor.ErrorResponseInterceptor
 import com.weit2nd.data.interceptor.LoginInterceptor
@@ -72,12 +73,14 @@ object NetworkModule {
         authInterceptor: AuthInterceptor,
         loggingInterceptor: HttpLoggingInterceptor,
         errorResponseInterceptor: ErrorResponseInterceptor,
+        authAuthenticator: AuthAuthenticator,
     ): OkHttpClient =
         OkHttpClient
             .Builder()
             .addInterceptor(authInterceptor)
             .addInterceptor(loggingInterceptor)
             .addInterceptor(errorResponseInterceptor)
+            .authenticator(authAuthenticator)
             .build()
 
     @DefaultNetwork

--- a/data/src/main/java/com/weit2nd/data/interceptor/AuthAuthenticator.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/AuthAuthenticator.kt
@@ -1,0 +1,42 @@
+package com.weit2nd.data.interceptor
+
+import com.weit2nd.data.interceptor.AuthInterceptor.Companion.AUTHORIZATION_HEADER
+import com.weit2nd.data.interceptor.AuthInterceptor.Companion.BEARER_PREFIX
+import com.weit2nd.data.source.token.TokenDataSource
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import javax.inject.Inject
+
+class AuthAuthenticator @Inject constructor(
+    private val dataSource: TokenDataSource,
+) : Authenticator {
+
+    override fun authenticate(route: Route?, response: Response): Request? {
+        val mutex = Mutex()
+        var request: Request? = null
+        runBlocking {
+            mutex.withLock {
+                val usedToken = response.request.header(AUTHORIZATION_HEADER)
+                val lastUpdatedToken = BEARER_PREFIX + dataSource.getAccessToken()
+                if (usedToken == lastUpdatedToken) {
+                    runCatching {
+                        dataSource.refreshAccessToken()
+                    }.onSuccess {
+                        request = response.request.newBuilder()
+                            .header(
+                                AUTHORIZATION_HEADER,
+                                BEARER_PREFIX + dataSource.getAccessToken()
+                            )
+                            .build()
+                    }
+                }
+            }
+        }
+        return request
+    }
+}

--- a/data/src/main/java/com/weit2nd/data/interceptor/AuthAuthenticator.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/AuthAuthenticator.kt
@@ -17,7 +17,10 @@ class AuthAuthenticator @Inject constructor(
 ) : Authenticator {
     private val mutex = Mutex()
 
-    override fun authenticate(route: Route?, response: Response): Request? {
+    override fun authenticate(
+        route: Route?,
+        response: Response,
+    ): Request? {
         var request: Request? = null
         runBlocking {
             mutex.withLock {
@@ -27,12 +30,13 @@ class AuthAuthenticator @Inject constructor(
                     runCatching {
                         dataSource.refreshAccessToken()
                     }.onSuccess {
-                        request = response.request.newBuilder()
-                            .header(
-                                AUTHORIZATION_HEADER,
-                                BEARER_PREFIX + dataSource.getAccessToken()
-                            )
-                            .build()
+                        request =
+                            response.request
+                                .newBuilder()
+                                .header(
+                                    AUTHORIZATION_HEADER,
+                                    BEARER_PREFIX + dataSource.getAccessToken(),
+                                ).build()
                     }
                 }
             }

--- a/data/src/main/java/com/weit2nd/data/interceptor/AuthAuthenticator.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/AuthAuthenticator.kt
@@ -15,9 +15,9 @@ import javax.inject.Inject
 class AuthAuthenticator @Inject constructor(
     private val dataSource: TokenDataSource,
 ) : Authenticator {
+    private val mutex = Mutex()
 
     override fun authenticate(route: Route?, response: Response): Request? {
-        val mutex = Mutex()
         var request: Request? = null
         runBlocking {
             mutex.withLock {

--- a/data/src/main/java/com/weit2nd/data/interceptor/AuthInterceptor.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/AuthInterceptor.kt
@@ -9,7 +9,6 @@ class AuthInterceptor @Inject constructor(
     private val dataSource: TokenDataSource,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        // TODO 만료된 액세스 토큰 갱신 로직 추가
         val authorization = BEARER_PREFIX + dataSource.getAccessToken()
         val newRequest =
             chain.request().newBuilder().apply {
@@ -19,7 +18,7 @@ class AuthInterceptor @Inject constructor(
     }
 
     companion object {
-        private const val AUTHORIZATION_HEADER = "Authorization"
-        private const val BEARER_PREFIX = "Bearer "
+        const val AUTHORIZATION_HEADER = "Authorization"
+        const val BEARER_PREFIX = "Bearer "
     }
 }

--- a/data/src/main/java/com/weit2nd/data/interceptor/LoginInterceptor.kt
+++ b/data/src/main/java/com/weit2nd/data/interceptor/LoginInterceptor.kt
@@ -24,14 +24,15 @@ class LoginInterceptor @Inject constructor(
                 chain.proceed(newRequest.build())
             },
             onFailure = {
-                Response.Builder()
+                Response
+                    .Builder()
                     .request(chain.request())
                     .protocol(Protocol.HTTP_1_1)
                     .code(HTTP_UNAUTHORIZED)
                     .message("${it.message}")
                     .body(it.stackTraceToString().toResponseBody())
                     .build()
-            }
+            },
         )
     }
 


### PR DESCRIPTION
### 개요
- 토큰 자동 갱신 기능
### 변경사항
- AuthAuthenticator 생성

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-85) 

### 리뷰어에게 하고 싶은 말
- 아직도 아리까리 해서 코드에 대한 설명을 줄줄 써볼테니 괜찮은지 확인 부탁드려요!

- 401에러 발생시 자동으로 authenticate()가 실행된다.
- 이 안에서 mutex를 사용하여 코루틴이 하나씩 실행되도록 하였다. 이렇게해서 만약 여러 api에서 토큰이 만료되었을 경우 순차적으로 mutex안에 들어오게 될 것이다.
- 여러 api에서 동시에 토큰이 만료되었을 경우에 매번 토큰을 갱신해줄 수 없으니, request할 때 보냈던 accessToken과 dataSource에서 가지고 있는 accessToken이 같은지를 확인한다.
- 만약 같다면 아직 토큰이 갱신되지 않은 것이기 때문에 refreshAccessToken()을 해주고, 그렇지 않다면 갱신해주지 않는다.