### PR TITLE
ROFO-99 회원가입 로딩 동작

### DIFF
--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -141,7 +141,7 @@ private fun NavGraphBuilder.signUpComposable(navController: NavHostController) {
         SignUpScreen(
             navToHome = { user ->
                 navController.navigateToHome(user) {
-                    popUpTo(SignUpNavRoutes.GRAPH) {
+                    popUpTo("${SignUpNavRoutes.GRAPH}/{${SignUpNavRoutes.TERM_IDS}}") {
                         inclusive = true
                     }
                 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/common/LoadingDialogScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/common/LoadingDialogScreen.kt
@@ -1,0 +1,37 @@
+package com.weit2nd.presentation.ui.common
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+
+@Composable
+fun LoadingDialogScreen(
+    modifier: Modifier = Modifier,
+    onDismissRequest: () -> Unit = {},
+    properties: DialogProperties = DialogProperties(),
+) {
+    Dialog(
+        onDismissRequest = { onDismissRequest() },
+        properties = properties,
+    ) {
+        Card(
+            modifier = modifier,
+            shape = RoundedCornerShape(16.dp),
+        ) {
+            CircularProgressIndicator(
+                modifier =
+                    Modifier
+                        .wrapContentSize(Alignment.Center)
+                        .padding(16.dp),
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpIntent.kt
@@ -13,7 +13,7 @@ sealed class SignUpIntent {
         val nickname: String,
     ) : SignUpIntent()
 
-    data class SetLoadingState(
+    data class SetNicknameCheckingLoadingState(
         val isLoading: Boolean,
     ) : SignUpIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpScreen.kt
@@ -89,7 +89,7 @@ fun SignUpScreen(
         Button(
             modifier = Modifier.fillMaxWidth(),
             onClick = vm::onSignUpButtonClick,
-            enabled = state.value.nicknameState == NicknameState.CAN_SIGN_UP,
+            enabled = (state.value.nicknameState == NicknameState.CAN_SIGN_UP) && state.value.isSignUpLoading.not(),
         ) {
             Text(text = stringResource(R.string.sign_up))
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpScreen.kt
@@ -32,6 +32,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.weit2nd.domain.model.NicknameState
 import com.weit2nd.domain.model.User
 import com.weit2nd.presentation.R
+import com.weit2nd.presentation.ui.common.LoadingDialogScreen
 import com.weit2nd.presentation.ui.common.ProfileImage
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -49,6 +50,10 @@ fun SignUpScreen(
             navToHome = navToHome,
             context = context,
         )
+    }
+
+    if (state.value.isSignUpLoading) {
+        LoadingDialogScreen()
     }
 
     Column(

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpScreen.kt
@@ -75,7 +75,7 @@ fun SignUpScreen(
                         .padding(24.dp),
                 nickname = state.value.nickname,
                 nicknameState = state.value.nicknameState,
-                isLoading = state.value.isLoading,
+                isLoading = state.value.isNicknameCheckingLoading,
                 onInputValueChange = vm::onNicknameInputValueChange,
                 onDuplicationBtnClick = vm::onDuplicationBtnClick,
             )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpState.kt
@@ -8,4 +8,5 @@ data class SignUpState(
     val nickname: String = "",
     val isNicknameCheckingLoading: Boolean = false,
     val nicknameState: NicknameState = NicknameState.EMPTY,
+    val isSignUpLoading: Boolean = false,
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpState.kt
@@ -6,6 +6,6 @@ import com.weit2nd.domain.model.NicknameState
 data class SignUpState(
     val profileImageUri: Uri? = null,
     val nickname: String = "",
-    val isLoading: Boolean = false,
+    val isNicknameCheckingLoading: Boolean = false,
     val nicknameState: NicknameState = NicknameState.EMPTY,
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
@@ -68,6 +68,11 @@ class SignUpViewModel @Inject constructor(
         intent {
             when (this@post) {
                 SignUpIntent.RequestSignUp -> {
+                    reduce {
+                        state.copy(
+                            isSignUpLoading = true,
+                        )
+                    }
                     runCatching {
                         state.apply {
                             signUpUseCase.invoke(
@@ -83,6 +88,11 @@ class SignUpViewModel @Inject constructor(
                             postSideEffect(SignUpSideEffect.ShowToast("업로드된 파일이 이미지 형식이 아닙니다."))
                         } else {
                             throwable.message?.let { postSideEffect(SignUpSideEffect.ShowToast(it)) }
+                            reduce {
+                                state.copy(
+                                    isSignUpLoading = false,
+                                )
+                            }
                         }
                     }
                 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/signup/SignUpViewModel.kt
@@ -56,10 +56,10 @@ class SignUpViewModel @Inject constructor(
         SignUpIntent.CheckNicknameDuplication(container.stateFlow.value.nickname).post()
     }
 
-    private fun setLoadingState() {
+    private fun setNicknameCheckingLoadingState() {
         SignUpIntent
-            .SetLoadingState(
-                container.stateFlow.value.isLoading
+            .SetNicknameCheckingLoadingState(
+                container.stateFlow.value.isNicknameCheckingLoading
                     .not(),
             ).post()
     }
@@ -109,7 +109,7 @@ class SignUpViewModel @Inject constructor(
                 }
 
                 is SignUpIntent.CheckNicknameDuplication -> {
-                    setLoadingState()
+                    setNicknameCheckingLoadingState()
                     nicknameDuplicateCheckJob =
                         viewModelScope
                             .launch {
@@ -123,15 +123,15 @@ class SignUpViewModel @Inject constructor(
                                 }
                             }.apply {
                                 invokeOnCompletion {
-                                    setLoadingState()
+                                    setNicknameCheckingLoadingState()
                                 }
                             }
                 }
 
-                is SignUpIntent.SetLoadingState -> {
+                is SignUpIntent.SetNicknameCheckingLoadingState -> {
                     reduce {
                         state.copy(
-                            isLoading = isLoading,
+                            isNicknameCheckingLoading = isLoading,
                         )
                     }
                 }


### PR DESCRIPTION
### 개요
- 회원가입 로딩 동작 추가
### 변경사항
- 로딩 다이얼로그 화면 생성
- 회원가입 로딩 동작 추가
![Jul-17-2024 23-31-30](https://github.com/user-attachments/assets/c039f9e0-3841-458b-803b-80f34c412faa)
당장 디자인은 안중요하지만 일단 이런식으로 만들었다 보여드리기 위한 gif

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-99) 

### 리뷰어에게 하고 싶은 말
- 사이드이펙트로 로딩 다이얼로그를 보여줘야하는것 아닌가 하는 생각으로 이리저리 시도해보았는데, 로딩 다이얼로그 자체가 Composable이라 안되더라구요.. 검색해보니 사람들이 지금처럼(if(state값)) 하길래 일단 이렇게 해보았습니다. 좋은 의견있다면 피드백 부탁드려요!
- 화면 밖 터치, 뒤로가기 클릭 시 다이얼로그 없어지는 기능도 시도해봤는데, 회원가입job을 cancel하는 속도보다 회원가입이 되어버리는 속도가 빨라서 화면은 안넘어가고 그대로인데 이미 회원가입은 되어버린 상태가 반복되었습니다. 그래서 그냥 아예 회원가입 중간에는 cancel하지 못하도록 막았습니다ㅎ