### PR TITLE
ROFO-91 사용자별 음식점 리포트 기록 조회 api 연결

### DIFF
--- a/data/src/main/java/com/weit2nd/data/model/spot/FoodSpotHistoriesDTO.kt
+++ b/data/src/main/java/com/weit2nd/data/model/spot/FoodSpotHistoriesDTO.kt
@@ -1,0 +1,35 @@
+package com.weit2nd.data.model.spot
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class FoodSpotHistoriesDTO(
+    @field:Json(name = "contents") val contents: List<FoodSpotHistoryContentDTO>,
+    @field:Json(name = "hasNext") val hasNext: Boolean,
+)
+
+@JsonClass(generateAdapter = true)
+data class FoodSpotHistoryContentDTO(
+    @field:Json(name = "id") val id: Long,
+    @field:Json(name = "userId") val userId: Long,
+    @field:Json(name = "foodSpotsId") val foodSpotsId: Long,
+    @field:Json(name = "name") val name: String,
+    @field:Json(name = "longitude") val longitude: Double,
+    @field:Json(name = "latitude") val latitude: Double,
+    @field:Json(name = "createdDateTime") val createdDateTime: String,
+    @field:Json(name = "reportPhotos") val reportPhotos: List<FoodSpotReportPhotoDTO>,
+    @field:Json(name = "categories") val categories: List<FoodSpotCategoryDTO>,
+)
+
+@JsonClass(generateAdapter = true)
+data class FoodSpotReportPhotoDTO(
+    @field:Json(name = "id") val id: Long,
+    @field:Json(name = "url") val url: String,
+)
+
+@JsonClass(generateAdapter = true)
+data class FoodSpotCategoryDTO(
+    @field:Json(name = "id") val id: Long,
+    @field:Json(name = "name") val name: String,
+)

--- a/data/src/main/java/com/weit2nd/data/model/spot/FoodSpotHistoriesDTO.kt
+++ b/data/src/main/java/com/weit2nd/data/model/spot/FoodSpotHistoriesDTO.kt
@@ -2,6 +2,8 @@ package com.weit2nd.data.model.spot
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import com.weit2nd.data.util.StringToLocalDateTime
+import java.time.LocalDateTime
 
 @JsonClass(generateAdapter = true)
 data class FoodSpotHistoriesDTO(
@@ -17,7 +19,7 @@ data class FoodSpotHistoryContentDTO(
     @field:Json(name = "name") val name: String,
     @field:Json(name = "longitude") val longitude: Double,
     @field:Json(name = "latitude") val latitude: Double,
-    @field:Json(name = "createdDateTime") val createdDateTime: String,
+    @field:Json(name = "createdDateTime") @StringToLocalDateTime val createdDateTime: LocalDateTime,
     @field:Json(name = "reportPhotos") val reportPhotos: List<FoodSpotReportPhotoDTO>,
     @field:Json(name = "categories") val categories: List<FoodSpotCategoryDTO>,
 )

--- a/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
@@ -125,7 +125,7 @@ class FoodSpotRepositoryImpl @Inject constructor(
     override suspend fun getFoodSpotHistories(
         userId: Long,
         count: Int,
-        lastItemId: Long,
+        lastItemId: Long?,
     ): FoodSpotHistories {
         return foodSpotDataSource
             .getFoodSpotHistories(

--- a/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
@@ -1,12 +1,20 @@
 package com.weit2nd.data.repository.spot
 
 import com.squareup.moshi.Moshi
+import com.weit2nd.data.model.spot.FoodSpotCategoryDTO
+import com.weit2nd.data.model.spot.FoodSpotHistoriesDTO
+import com.weit2nd.data.model.spot.FoodSpotHistoryContentDTO
+import com.weit2nd.data.model.spot.FoodSpotReportPhotoDTO
 import com.weit2nd.data.model.spot.ReportFoodSpotRequest
 import com.weit2nd.data.model.spot.toRequest
 import com.weit2nd.data.source.localimage.LocalImageDatasource
 import com.weit2nd.data.source.spot.FoodSpotDataSource
 import com.weit2nd.data.util.getMultiPart
 import com.weit2nd.domain.exception.imageuri.NotImageException
+import com.weit2nd.domain.model.spot.FoodSpotCategory
+import com.weit2nd.domain.model.spot.FoodSpotHistories
+import com.weit2nd.domain.model.spot.FoodSpotHistoryContent
+import com.weit2nd.domain.model.spot.FoodSpotPhoto
 import com.weit2nd.domain.model.spot.OperationHour
 import com.weit2nd.domain.model.spot.ReportFoodSpotState
 import com.weit2nd.domain.repository.spot.FoodSpotRepository
@@ -113,6 +121,50 @@ class FoodSpotRepositoryImpl @Inject constructor(
         // TODO 이미지 uri 검증
         return null
     }
+
+    override suspend fun getFoodSpotHistories(
+        userId: Long,
+        count: Int,
+        lastItemId: Long,
+    ): FoodSpotHistories {
+        return foodSpotDataSource
+            .getFoodSpotHistories(
+                userId = userId,
+                count = count,
+                lastItemId = lastItemId,
+            ).toFoodSpotHistories()
+    }
+
+    private fun FoodSpotHistoriesDTO.toFoodSpotHistories() =
+        FoodSpotHistories(
+            contents = contents.map { it.toFoodSpotHistoryContent() },
+            hasNext = hasNext,
+        )
+
+    private fun FoodSpotHistoryContentDTO.toFoodSpotHistoryContent() =
+        FoodSpotHistoryContent(
+            id = id,
+            userId = userId,
+            foodSpotsId = foodSpotsId,
+            name = name,
+            longitude = longitude,
+            latitude = latitude,
+            createdDateTime = createdDateTime,
+            reportPhotos = reportPhotos.map { it.toFoodSpotPhoto() },
+            categories = categories.map { it.toFoodSpotCategory() },
+        )
+
+    private fun FoodSpotReportPhotoDTO.toFoodSpotPhoto() =
+        FoodSpotPhoto(
+            id = id,
+            url = url,
+        )
+
+    private fun FoodSpotCategoryDTO.toFoodSpotCategory() =
+        FoodSpotCategory(
+            id = id,
+            name = name,
+        )
 
     companion object {
         private const val MAX_COORDINATE = 180f

--- a/data/src/main/java/com/weit2nd/data/service/SpotService.kt
+++ b/data/src/main/java/com/weit2nd/data/service/SpotService.kt
@@ -1,9 +1,13 @@
 package com.weit2nd.data.service
 
+import com.weit2nd.data.model.spot.FoodSpotHistoriesDTO
 import okhttp3.MultipartBody
+import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
+import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface SpotService {
     @Multipart
@@ -12,4 +16,11 @@ interface SpotService {
         @Part reportRequest: MultipartBody.Part,
         @Part reportPhotos: List<MultipartBody.Part>?,
     )
+
+    @GET("/api/v1/food-spots/histories/{userId}")
+    suspend fun getFoodSpotHistories(
+        @Path("userId") userId: Long,
+        @Query("size") size: Int,
+        @Query("lastId") lastId: Long,
+    ): FoodSpotHistoriesDTO
 }

--- a/data/src/main/java/com/weit2nd/data/service/SpotService.kt
+++ b/data/src/main/java/com/weit2nd/data/service/SpotService.kt
@@ -21,6 +21,6 @@ interface SpotService {
     suspend fun getFoodSpotHistories(
         @Path("userId") userId: Long,
         @Query("size") size: Int,
-        @Query("lastId") lastId: Long,
+        @Query("lastId") lastId: Long?,
     ): FoodSpotHistoriesDTO
 }

--- a/data/src/main/java/com/weit2nd/data/source/spot/FoodSpotDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/spot/FoodSpotDataSource.kt
@@ -1,8 +1,8 @@
 package com.weit2nd.data.source.spot
 
+import com.weit2nd.data.model.spot.FoodSpotHistoriesDTO
 import com.weit2nd.data.service.SpotService
 import okhttp3.MultipartBody
-import retrofit2.http.Part
 import javax.inject.Inject
 
 class FoodSpotDataSource @Inject constructor(
@@ -15,6 +15,18 @@ class FoodSpotDataSource @Inject constructor(
         service.reportFoodSpot(
             reportRequest = reportRequest,
             reportPhotos = reportPhotos,
+        )
+    }
+
+    suspend fun getFoodSpotHistories(
+        userId: Long,
+        count: Int,
+        lastItemId: Long,
+    ): FoodSpotHistoriesDTO {
+        return service.getFoodSpotHistories(
+            userId = userId,
+            size = count,
+            lastId = lastItemId,
         )
     }
 }

--- a/data/src/main/java/com/weit2nd/data/source/spot/FoodSpotDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/spot/FoodSpotDataSource.kt
@@ -21,7 +21,7 @@ class FoodSpotDataSource @Inject constructor(
     suspend fun getFoodSpotHistories(
         userId: Long,
         count: Int,
-        lastItemId: Long,
+        lastItemId: Long?,
     ): FoodSpotHistoriesDTO {
         return service.getFoodSpotHistories(
             userId = userId,

--- a/data/src/main/java/com/weit2nd/data/util/LocalDataTimeConverter.kt
+++ b/data/src/main/java/com/weit2nd/data/util/LocalDataTimeConverter.kt
@@ -11,7 +11,7 @@ import java.time.format.DateTimeFormatter
 annotation class StringToLocalDateTime
 
 class LocalDateTimeConverter {
-    private val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    private val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
 
     @ToJson
     fun toJson(

--- a/data/src/main/java/com/weit2nd/data/util/LocalDataTimeConverter.kt
+++ b/data/src/main/java/com/weit2nd/data/util/LocalDataTimeConverter.kt
@@ -11,7 +11,7 @@ import java.time.format.DateTimeFormatter
 annotation class StringToLocalDateTime
 
 class LocalDateTimeConverter {
-    private val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+    private val dateFormat = DateTimeFormatter.ISO_DATE_TIME
 
     @ToJson
     fun toJson(

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/FoodSpotCategory.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/FoodSpotCategory.kt
@@ -1,0 +1,6 @@
+package com.weit2nd.domain.model.spot
+
+data class FoodSpotCategory(
+    val id: Long,
+    val name: String,
+)

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/FoodSpotHistories.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/FoodSpotHistories.kt
@@ -1,5 +1,7 @@
 package com.weit2nd.domain.model.spot
 
+import java.time.LocalDateTime
+
 data class FoodSpotHistories(
     val contents: List<FoodSpotHistoryContent>,
     val hasNext: Boolean,
@@ -12,7 +14,7 @@ data class FoodSpotHistoryContent(
     val name: String,
     val longitude: Double,
     val latitude: Double,
-    val createdDateTime: String,
+    val createdDateTime: LocalDateTime,
     val reportPhotos: List<FoodSpotPhoto>,
     val categories: List<FoodSpotCategory>,
 )

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/FoodSpotHistories.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/FoodSpotHistories.kt
@@ -1,0 +1,18 @@
+package com.weit2nd.domain.model.spot
+
+data class FoodSpotHistories(
+    val contents: List<FoodSpotHistoryContent>,
+    val hasNext: Boolean,
+)
+
+data class FoodSpotHistoryContent(
+    val id: Long,
+    val userId: Long,
+    val foodSpotsId: Long,
+    val name: String,
+    val longitude: Double,
+    val latitude: Double,
+    val createdDateTime: String,
+    val reportPhotos: List<FoodSpotPhoto>,
+    val categories: List<FoodSpotCategory>,
+)

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/FoodSpotPhoto.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/FoodSpotPhoto.kt
@@ -1,0 +1,6 @@
+package com.weit2nd.domain.model.spot
+
+data class FoodSpotPhoto(
+    val id: Long,
+    val url: String,
+)

--- a/domain/src/main/java/com/weit2nd/domain/repository/spot/FoodSpotRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/spot/FoodSpotRepository.kt
@@ -1,5 +1,6 @@
 package com.weit2nd.domain.repository.spot
 
+import com.weit2nd.domain.model.spot.FoodSpotHistories
 import com.weit2nd.domain.model.spot.OperationHour
 import com.weit2nd.domain.model.spot.ReportFoodSpotState
 
@@ -22,4 +23,10 @@ interface FoodSpotRepository {
         latitude: Double,
         images: List<String>,
     ): ReportFoodSpotState
+
+    suspend fun getFoodSpotHistories(
+        userId: Long,
+        count: Int,
+        lastItemId: Long,
+    ): FoodSpotHistories
 }

--- a/domain/src/main/java/com/weit2nd/domain/repository/spot/FoodSpotRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/spot/FoodSpotRepository.kt
@@ -27,6 +27,6 @@ interface FoodSpotRepository {
     suspend fun getFoodSpotHistories(
         userId: Long,
         count: Int,
-        lastItemId: Long,
+        lastItemId: Long?,
     ): FoodSpotHistories
 }

--- a/domain/src/main/java/com/weit2nd/domain/usecase/spot/GetFoodSpotHistories.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/spot/GetFoodSpotHistories.kt
@@ -1,0 +1,27 @@
+package com.weit2nd.domain.usecase.spot
+
+import com.weit2nd.domain.model.spot.FoodSpotHistories
+import com.weit2nd.domain.repository.spot.FoodSpotRepository
+import javax.inject.Inject
+
+class GetFoodSpotHistories @Inject constructor(
+    private val repository: FoodSpotRepository,
+) {
+    /**
+     * 사용자 아이디를 통해 해당 사용자가 작성한 음식점 리포트들을 조회합니다.
+     * @param userId 사용자 아이디
+     * @param count 조회할 개수
+     * @param lastItemId 마지막으로 조회된 요소의 아이디
+     */
+    suspend fun invoke(
+        userId: Long,
+        count: Int,
+        lastItemId: Long,
+    ): FoodSpotHistories {
+        return repository.getFoodSpotHistories(
+            userId = userId,
+            count = count,
+            lastItemId = lastItemId,
+        )
+    }
+}

--- a/domain/src/main/java/com/weit2nd/domain/usecase/spot/GetFoodSpotHistoriesUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/spot/GetFoodSpotHistoriesUseCase.kt
@@ -4,7 +4,7 @@ import com.weit2nd.domain.model.spot.FoodSpotHistories
 import com.weit2nd.domain.repository.spot.FoodSpotRepository
 import javax.inject.Inject
 
-class GetFoodSpotHistories @Inject constructor(
+class GetFoodSpotHistoriesUseCase @Inject constructor(
     private val repository: FoodSpotRepository,
 ) {
     /**

--- a/domain/src/main/java/com/weit2nd/domain/usecase/spot/GetFoodSpotHistoriesUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/spot/GetFoodSpotHistoriesUseCase.kt
@@ -11,12 +11,12 @@ class GetFoodSpotHistoriesUseCase @Inject constructor(
      * 사용자 아이디를 통해 해당 사용자가 작성한 음식점 리포트들을 조회합니다.
      * @param userId 사용자 아이디
      * @param count 조회할 개수
-     * @param lastItemId 마지막으로 조회된 요소의 아이디 (첫 페이지를 조회하는 경우 1을 넣어줍니다.)
+     * @param lastItemId 마지막으로 조회된 요소의 아이디 (첫 페이지를 조회하는 경우 빈 값을 넣어줍니다.)
      */
     suspend fun invoke(
         userId: Long,
         count: Int,
-        lastItemId: Long = 1,
+        lastItemId: Long? = null,
     ): FoodSpotHistories {
         return repository.getFoodSpotHistories(
             userId = userId,

--- a/domain/src/main/java/com/weit2nd/domain/usecase/spot/GetFoodSpotHistoriesUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/spot/GetFoodSpotHistoriesUseCase.kt
@@ -11,12 +11,12 @@ class GetFoodSpotHistoriesUseCase @Inject constructor(
      * 사용자 아이디를 통해 해당 사용자가 작성한 음식점 리포트들을 조회합니다.
      * @param userId 사용자 아이디
      * @param count 조회할 개수
-     * @param lastItemId 마지막으로 조회된 요소의 아이디
+     * @param lastItemId 마지막으로 조회된 요소의 아이디 (첫 페이지를 조회하는 경우 1을 넣어줍니다.)
      */
     suspend fun invoke(
         userId: Long,
         count: Int,
-        lastItemId: Long,
+        lastItemId: Long = 1,
     ): FoodSpotHistories {
         return repository.getFoodSpotHistories(
             userId = userId,


### PR DESCRIPTION
### 개요
- 사용자별 음식점 리포트 기록 조회 api 연결
### 변경사항
- 사용자별 음식점 리포트 기록 조회 api 연결

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-91) 

### 리뷰어에게 하고 싶은 말
- 사용자 id를 통해서 해당 사용자의 리포트 기록을 조회하는 것인데 현재 함수명이나 유즈케이스명에서 그 뜻이 잘 전해지나요?
- 자칫하면 본인의 리포트 기록을 조회하는 것으로 착각할 수도 있는 이름같아서 물어봅니당
- 현재 createdDateTime 값을 도메인에서도 그냥 String으로 갖고 있습니다. 나중에 화면에서 원하는 형태로 포맷팅할 때 LocalDateTime을 쓰면 되지않을까해서 냅뒀는데 어떻게 생각하시나요?