### PR TITLE
ROFO-101 음식점 리포트 화면 (프리스타일 ver)

### DIFF
--- a/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
@@ -144,8 +144,7 @@ class FoodSpotRepositoryImpl @Inject constructor(
     }
 
     private fun findInvalidImage(images: List<String>): String? {
-        // TODO 이미지 uri 검증
-        return null
+        return localImageDatasource.findInvalidImage(images)
     }
 
     override suspend fun getFoodSpotHistories(

--- a/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
@@ -195,6 +195,6 @@ class FoodSpotRepositoryImpl @Inject constructor(
         private const val MAX_COORDINATE = 180f
         private const val MIN_COORDINATE = -180f
         private const val MAX_IMAGE_COUNT = 3
-        private val foodSpotNameRegex = Regex("^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9!@#\$%^&*()\\-\\+ ]{1,20}\$")
+        private val foodSpotNameRegex = Regex("^[가-힣a-zA-Z0-9.,'·&\\-\\s]{1,20}\$")
     }
 }

--- a/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
@@ -18,6 +18,9 @@ import com.weit2nd.domain.model.spot.FoodSpotPhoto
 import com.weit2nd.domain.model.spot.OperationHour
 import com.weit2nd.domain.model.spot.ReportFoodSpotState
 import com.weit2nd.domain.repository.spot.FoodSpotRepository
+import okhttp3.internal.http.HTTP_BAD_REQUEST
+import okhttp3.internal.http.HTTP_NOT_FOUND
+import retrofit2.HttpException
 import javax.inject.Inject
 
 class FoodSpotRepositoryImpl @Inject constructor(
@@ -64,16 +67,34 @@ class FoodSpotRepositoryImpl @Inject constructor(
                 fileName = "reportRequest",
                 request = request,
             )
-        foodSpotDataSource.reportFoodSpot(
-            reportRequest = reportFoodSpotPart,
-            reportPhotos = imageParts,
-        )
+
+        runCatching {
+            foodSpotDataSource.reportFoodSpot(
+                reportRequest = reportFoodSpotPart,
+                reportPhotos = imageParts,
+            )
+        }.onFailure { throwable ->
+            throw handleException(throwable)
+        }
     }
+
+    private fun handleException(throwable: Throwable) =
+        if (throwable is HttpException) {
+            val errorMessage = throwable.message()
+            when (throwable.code()) {
+                HTTP_BAD_REQUEST -> IllegalStateException(errorMessage)
+                HTTP_NOT_FOUND -> IllegalStateException(errorMessage)
+                else -> throwable
+            }
+        } else {
+            throwable
+        }
 
     override suspend fun verifyReport(
         name: String,
-        longitude: Double,
-        latitude: Double,
+        longitude: Double?,
+        latitude: Double?,
+        foodCategories: List<Long>,
         images: List<String>,
     ): ReportFoodSpotState {
         val invalidImage =
@@ -89,6 +110,10 @@ class FoodSpotRepositoryImpl @Inject constructor(
 
             verifyCoordinate(longitude, latitude).not() -> {
                 ReportFoodSpotState.BadCoordinate
+            }
+
+            foodCategories.isEmpty() -> {
+                ReportFoodSpotState.NoFoodCategory
             }
 
             images.size > MAX_IMAGE_COUNT -> {
@@ -110,9 +135,10 @@ class FoodSpotRepositoryImpl @Inject constructor(
     }
 
     private fun verifyCoordinate(
-        longitude: Double,
-        latitude: Double,
+        longitude: Double?,
+        latitude: Double?,
     ): Boolean {
+        if (longitude == null || latitude == null) return false
         return (longitude in MIN_COORDINATE..MAX_COORDINATE) &&
             (latitude in MIN_COORDINATE..MAX_COORDINATE)
     }

--- a/data/src/main/java/com/weit2nd/data/source/localimage/LocalImageDatasource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/localimage/LocalImageDatasource.kt
@@ -53,7 +53,8 @@ class LocalImageDatasource @Inject constructor(
                                     MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
                                     cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)),
                                 ).toString()
-                        val lastModified = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATE_MODIFIED))
+                        val lastModified =
+                            cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATE_MODIFIED))
                         val directory =
                             cursor
                                 .getString(
@@ -91,8 +92,14 @@ class LocalImageDatasource @Inject constructor(
                 putInt(ContentResolver.QUERY_ARG_LIMIT, count)
             }
             putInt(ContentResolver.QUERY_ARG_OFFSET, offset)
-            putStringArray(ContentResolver.QUERY_ARG_SORT_COLUMNS, arrayOf(MediaStore.Images.ImageColumns.DATE_MODIFIED))
-            putInt(ContentResolver.QUERY_ARG_SORT_DIRECTION, ContentResolver.QUERY_SORT_DIRECTION_DESCENDING)
+            putStringArray(
+                ContentResolver.QUERY_ARG_SORT_COLUMNS,
+                arrayOf(MediaStore.Images.ImageColumns.DATE_MODIFIED),
+            )
+            putInt(
+                ContentResolver.QUERY_ARG_SORT_DIRECTION,
+                ContentResolver.QUERY_SORT_DIRECTION_DESCENDING,
+            )
         }
 
     suspend fun getImageMultipartBodyPart(
@@ -155,12 +162,7 @@ class LocalImageDatasource @Inject constructor(
         }
     }
 
-    fun findInvalidImage(images: List<String>): String? {
-        images.forEach {
-            if (checkImageUriValid(it).not()) return it
-        }
-        return null
-    }
+    fun findInvalidImage(images: List<String>): String? = images.find { checkImageUriValid(it).not() }
 
     private fun checkReadableUri(uri: Uri): Boolean {
         contentResolver.openInputStream(uri).use { inputStream ->

--- a/data/src/main/java/com/weit2nd/data/source/localimage/LocalImageDatasource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/localimage/LocalImageDatasource.kt
@@ -155,6 +155,13 @@ class LocalImageDatasource @Inject constructor(
         }
     }
 
+    fun findInvalidImage(images: List<String>): String? {
+        images.forEach {
+            if (checkImageUriValid(it).not()) return it
+        }
+        return null
+    }
+
     private fun checkReadableUri(uri: Uri): Boolean {
         contentResolver.openInputStream(uri).use { inputStream ->
             if (inputStream == null) {

--- a/data/src/main/java/com/weit2nd/data/source/search/SearchPlaceDataSource.kt
+++ b/data/src/main/java/com/weit2nd/data/source/search/SearchPlaceDataSource.kt
@@ -36,8 +36,8 @@ class SearchPlaceDataSource @Inject constructor(
         return LocationDTO(
             name = "위치이름",
             address = "서울 중구 세종대로${coordinate.latitude}",
-            latitude = 0.0,
-            longitude = 0.0,
+            latitude = coordinate.latitude,
+            longitude = coordinate.longitude,
         )
     }
 }

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/OperationHour.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/OperationHour.kt
@@ -5,6 +5,6 @@ import java.time.LocalTime
 
 data class OperationHour(
     val dayOfWeek: DayOfWeek,
-    val openingHours: LocalTime = LocalTime.of(9, 0),
-    val closingHours: LocalTime = LocalTime.of(18, 0),
+    val openingHours: LocalTime,
+    val closingHours: LocalTime,
 )

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/OperationHour.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/OperationHour.kt
@@ -5,6 +5,6 @@ import java.time.LocalTime
 
 data class OperationHour(
     val dayOfWeek: DayOfWeek,
-    val openingHours: LocalTime,
-    val closingHours: LocalTime,
+    val openingHours: LocalTime = LocalTime.of(9, 0),
+    val closingHours: LocalTime = LocalTime.of(18, 0),
 )

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/ReportFoodSpotState.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/ReportFoodSpotState.kt
@@ -5,6 +5,8 @@ sealed class ReportFoodSpotState {
 
     data object BadFoodSpotName : ReportFoodSpotState()
 
+    data object NoFoodCategory : ReportFoodSpotState()
+
     data object TooManyImages : ReportFoodSpotState()
 
     data class InvalidImage(

--- a/domain/src/main/java/com/weit2nd/domain/repository/spot/FoodSpotRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/spot/FoodSpotRepository.kt
@@ -19,8 +19,9 @@ interface FoodSpotRepository {
 
     suspend fun verifyReport(
         name: String,
-        longitude: Double,
-        latitude: Double,
+        longitude: Double?,
+        latitude: Double?,
+        foodCategories: List<Long>,
         images: List<String>,
     ): ReportFoodSpotState
 

--- a/domain/src/main/java/com/weit2nd/domain/usecase/spot/VerifyReportUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/spot/VerifyReportUseCase.kt
@@ -12,18 +12,21 @@ class VerifyReportUseCase @Inject constructor(
      * @param name 음식점 이름
      * @param longitude 음식점 좌표 (경도)
      * @param latitude 음식점 좌표 (위도)
+     * @param foodCategories 사용자가 선택한 음식 카테고리 id 리스트
      * @param images 음식점 이미지
      */
     suspend operator fun invoke(
         name: String,
-        longitude: Double,
-        latitude: Double,
+        longitude: Double?,
+        latitude: Double?,
+        foodCategories: List<Long>,
         images: List<String>,
     ): ReportFoodSpotState {
         return repository.verifyReport(
             name = name,
             longitude = longitude,
             latitude = latitude,
+            foodCategories = foodCategories,
             images = images,
         )
     }

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -31,7 +31,7 @@ import com.weit2nd.presentation.ui.home.HomeScreen
 import com.weit2nd.presentation.ui.login.LoginScreen
 import com.weit2nd.presentation.ui.select.picture.SelectPictureScreen
 import com.weit2nd.presentation.ui.select.place.SelectPlaceScreen
-import com.weit2nd.presentation.ui.select.place.map.SelectLocationMapScreen
+import com.weit2nd.presentation.ui.select.place.map.SelectPlaceMapScreen
 import com.weit2nd.presentation.ui.signup.SignUpScreen
 import com.weit2nd.presentation.ui.signup.terms.TermsScreen
 import com.weit2nd.presentation.ui.signup.terms.detail.TermDetailScreen
@@ -55,8 +55,8 @@ fun AppNavHost(
         signUpComposable(navController)
         homeComposable(navController)
         selectPictureComposable(navController)
-        selectLocationComposable(navController)
-        selectLocationMapComposable(navController)
+        selectPlaceComposable(navController)
+        selectPlaceMapComposable(navController)
         termDetailComposable(navController)
         imageViewerComposable(navController)
         foodSpotReportComposable(navController)
@@ -171,12 +171,12 @@ private fun NavGraphBuilder.selectPictureComposable(navController: NavHostContro
     }
 }
 
-private fun NavGraphBuilder.selectLocationComposable(navController: NavHostController) {
-    composable(SelectLocationRoutes.GRAPH) {
+private fun NavGraphBuilder.selectPlaceComposable(navController: NavHostController) {
+    composable(SelectPlaceRoutes.GRAPH) {
         SelectPlaceScreen(
             navToMap = {
                 navController.navigateToSelectLocationMap {
-                    popUpTo(SelectLocationMapRoutes.GRAPH) {
+                    popUpTo(SelectPlaceMapRoutes.GRAPH) {
                         inclusive = true
                     }
                 }
@@ -185,17 +185,17 @@ private fun NavGraphBuilder.selectLocationComposable(navController: NavHostContr
     }
 }
 
-private fun NavGraphBuilder.selectLocationMapComposable(navController: NavHostController) {
+private fun NavGraphBuilder.selectPlaceMapComposable(navController: NavHostController) {
     composable(
-        route = "${SelectLocationMapRoutes.GRAPH}/{${SelectLocationMapRoutes.INITIAL_POSITION_KEY}}",
+        route = "${SelectPlaceMapRoutes.GRAPH}/{${SelectPlaceMapRoutes.INITIAL_POSITION_KEY}}",
         arguments =
             listOf(
-                navArgument(SelectLocationMapRoutes.INITIAL_POSITION_KEY) {
+                navArgument(SelectPlaceMapRoutes.INITIAL_POSITION_KEY) {
                     type = CoordinateType()
                 },
             ),
     ) {
-        SelectLocationMapScreen()
+        SelectPlaceMapScreen()
     }
 }
 
@@ -238,7 +238,7 @@ private fun NavHostController.navigateToSelectLocationMap(
     builder: NavOptionsBuilder.() -> Unit = {},
 ) {
     val coordinateJson = Uri.encode(Gson().toJson(coordinate.toCoordinateDTO()))
-    navigate("${SelectLocationMapRoutes.GRAPH}/$coordinateJson", builder)
+    navigate("${SelectPlaceMapRoutes.GRAPH}/$coordinateJson", builder)
 }
 
 private fun NavHostController.navigateToTermDetail(termId: Long) {
@@ -294,12 +294,12 @@ object SelectPictureRoutes {
     const val GRAPH = "select_picture"
 }
 
-object SelectLocationRoutes {
-    const val GRAPH = "select_location"
+object SelectPlaceRoutes {
+    const val GRAPH = "select_place"
 }
 
-object SelectLocationMapRoutes {
-    const val GRAPH = "select_location_map"
+object SelectPlaceMapRoutes {
+    const val GRAPH = "select_place_map"
     const val INITIAL_POSITION_KEY = "initial_position"
 }
 

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -18,6 +18,7 @@ import com.weit2nd.domain.model.Coordinate
 import com.weit2nd.domain.model.User
 import com.weit2nd.presentation.navigation.dto.toCoordinateDTO
 import com.weit2nd.presentation.navigation.dto.toImageViewerDTO
+import com.weit2nd.presentation.navigation.dto.toPlaceDTO
 import com.weit2nd.presentation.navigation.dto.toTermIdsDTO
 import com.weit2nd.presentation.navigation.dto.toUserDTO
 import com.weit2nd.presentation.navigation.type.CoordinateType
@@ -181,6 +182,14 @@ private fun NavGraphBuilder.selectPlaceComposable(navController: NavHostControll
                     }
                 }
             },
+            onSelectPlace = { place ->
+                navController.previousBackStackEntry?.savedStateHandle?.set(
+                    SelectPlaceRoutes.SELECT_PLACE_KEY,
+                    place.toPlaceDTO(),
+                )
+                navController.popBackStack()
+            },
+            navController = navController,
         )
     }
 }
@@ -195,7 +204,15 @@ private fun NavGraphBuilder.selectPlaceMapComposable(navController: NavHostContr
                 },
             ),
     ) {
-        SelectPlaceMapScreen()
+        SelectPlaceMapScreen(
+            onSelectPlace = { place ->
+                navController.previousBackStackEntry?.savedStateHandle?.set(
+                    SelectPlaceMapRoutes.SELECT_PLACE_KEY,
+                    place.toPlaceDTO(),
+                )
+                navController.popBackStack()
+            },
+        )
     }
 }
 
@@ -218,9 +235,13 @@ private fun NavGraphBuilder.imageViewerComposable(navController: NavHostControll
 private fun NavGraphBuilder.foodSpotReportComposable(navController: NavHostController) {
     composable(FoodSpotReportRoutes.GRAPH) {
         FoodSpotReportScreen(
+            navToSelectPlace = {
+                navController.navigate(SelectPlaceRoutes.GRAPH)
+            },
             navToBack = {
                 navController.popBackStack()
             },
+            navController = navController,
         )
     }
 }
@@ -296,11 +317,13 @@ object SelectPictureRoutes {
 
 object SelectPlaceRoutes {
     const val GRAPH = "select_place"
+    const val SELECT_PLACE_KEY = "select_place_selected_key"
 }
 
 object SelectPlaceMapRoutes {
     const val GRAPH = "select_place_map"
     const val INITIAL_POSITION_KEY = "initial_position"
+    const val SELECT_PLACE_KEY = "select_place_map_selected_key"
 }
 
 object ImageViewerRoutes {

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -26,6 +26,7 @@ import com.weit2nd.presentation.navigation.type.TermIdsType
 import com.weit2nd.presentation.navigation.type.UserType
 import com.weit2nd.presentation.ui.common.imageviewer.ImageViewerData
 import com.weit2nd.presentation.ui.common.imageviewer.ImageViewerScreen
+import com.weit2nd.presentation.ui.foodspot.report.FoodSpotReportScreen
 import com.weit2nd.presentation.ui.home.HomeScreen
 import com.weit2nd.presentation.ui.login.LoginScreen
 import com.weit2nd.presentation.ui.select.picture.SelectPictureScreen
@@ -58,6 +59,7 @@ fun AppNavHost(
         selectLocationMapComposable(navController)
         termDetailComposable(navController)
         imageViewerComposable(navController)
+        foodSpotReportComposable(navController)
     }
 }
 
@@ -155,7 +157,11 @@ private fun NavGraphBuilder.homeComposable(navController: NavHostController) {
         route = "${HomeNavRoutes.GRAPH}/{${HomeNavRoutes.USER_STATE_KEY}}",
         arguments = listOf(navArgument(HomeNavRoutes.USER_STATE_KEY) { type = UserType() }),
     ) {
-        HomeScreen()
+        HomeScreen(
+            navToFoodSpotReport = {
+                navController.navigate(FoodSpotReportRoutes.GRAPH)
+            },
+        )
     }
 }
 
@@ -205,6 +211,16 @@ private fun NavGraphBuilder.imageViewerComposable(navController: NavHostControll
     ) {
         ImageViewerScreen(
             onExitBtnClick = { navController.popBackStack() },
+        )
+    }
+}
+
+private fun NavGraphBuilder.foodSpotReportComposable(navController: NavHostController) {
+    composable(FoodSpotReportRoutes.GRAPH) {
+        FoodSpotReportScreen(
+            navToBack = {
+                navController.popBackStack()
+            },
         )
     }
 }
@@ -290,4 +306,8 @@ object SelectLocationMapRoutes {
 object ImageViewerRoutes {
     const val GRAPH = "image_viewer"
     const val IMAGES_VIEWER_DATA_KEY = "image_viewer_data"
+}
+
+object FoodSpotReportRoutes {
+    const val GRAPH = "food_spot_report"
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/PlaceDTO.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/PlaceDTO.kt
@@ -1,0 +1,35 @@
+package com.weit2nd.presentation.navigation.dto
+
+import android.os.Parcelable
+import com.weit2nd.domain.model.search.Place
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PlaceDTO(
+    val placeName: String,
+    val addressName: String,
+    val roadAddressName: String,
+    val longitude: Double,
+    val latitude: Double,
+    val tel: String,
+) : Parcelable
+
+fun PlaceDTO.toPlace(): Place =
+    Place(
+        placeName = placeName,
+        addressName = addressName,
+        roadAddressName = roadAddressName,
+        longitude = longitude,
+        latitude = latitude,
+        tel = tel,
+    )
+
+fun Place.toPlaceDTO(): PlaceDTO =
+    PlaceDTO(
+        placeName = placeName,
+        addressName = addressName,
+        roadAddressName = roadAddressName,
+        longitude = longitude,
+        latitude = latitude,
+        tel = tel,
+    )

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/type/PlaceType.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/type/PlaceType.kt
@@ -1,0 +1,32 @@
+package com.weit2nd.presentation.navigation.type
+
+import android.os.Build
+import android.os.Bundle
+import androidx.navigation.NavType
+import com.google.gson.Gson
+import com.weit2nd.presentation.navigation.dto.PlaceDTO
+
+class PlaceType : NavType<PlaceDTO>(isNullableAllowed = false) {
+    override fun get(
+        bundle: Bundle,
+        key: String,
+    ): PlaceDTO? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            bundle.getParcelable(key, PlaceDTO::class.java)
+        } else {
+            bundle.getParcelable(key)
+        }
+    }
+
+    override fun parseValue(value: String): PlaceDTO {
+        return Gson().fromJson(value, PlaceDTO::class.java)
+    }
+
+    override fun put(
+        bundle: Bundle,
+        key: String,
+        value: PlaceDTO,
+    ) {
+        bundle.putParcelable(key, value)
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/common/CancelableImage.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/common/CancelableImage.kt
@@ -1,0 +1,49 @@
+package com.weit2nd.presentation.ui.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
+
+@OptIn(ExperimentalGlideComposeApi::class)
+@Composable
+fun CancelableImage(
+    modifier: Modifier = Modifier,
+    imgUri: String,
+    onDeleteImage: ((String) -> Unit),
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.TopEnd,
+    ) {
+        GlideImage(
+            model = imgUri,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
+            contentDescription = null,
+        )
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth(0.2f)
+                    .background(Color.LightGray)
+                    .clickable { onDeleteImage(imgUri) },
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = "cancel_button",
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/common/CancelableImage.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/common/CancelableImage.kt
@@ -1,13 +1,14 @@
 package com.weit2nd.presentation.ui.common
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,12 +34,14 @@ fun CancelableImage(
             contentScale = ContentScale.Crop,
             contentDescription = null,
         )
-        Box(
+
+        IconButton(
             modifier =
                 Modifier
-                    .fillMaxWidth(0.2f)
                     .background(Color.LightGray)
-                    .clickable { onDeleteImage(imgUri) },
+                    .fillMaxWidth(0.2f)
+                    .fillMaxHeight(0.2f),
+            onClick = { onDeleteImage(imgUri) },
         ) {
             Icon(
                 imageVector = Icons.Filled.Close,

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
@@ -14,4 +14,10 @@ sealed class FoodSpotReportIntent {
     data class ChangeCategoryStatus(
         val categoryStatus: CategoryStatus,
     ) : FoodSpotReportIntent()
+
+    data object SelectImage : FoodSpotReportIntent()
+
+    data class DeleteImage(
+        val imgUri: String,
+    ) : FoodSpotReportIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
@@ -4,4 +4,8 @@ sealed class FoodSpotReportIntent {
     data class ChangeFoodTruckState(
         val isFoodTruck: Boolean,
     ) : FoodSpotReportIntent()
+
+    data class ChangeOpenState(
+        val isOpen: Boolean,
+    ) : FoodSpotReportIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
@@ -27,6 +27,7 @@ sealed class FoodSpotReportIntent {
 
     data class ChangeOperationHourStatus(
         val operationHourStatus: OperationHourStatus,
+        val isSelected: Boolean,
     ) : FoodSpotReportIntent()
 
     data class OpenTimePickerDialog(

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
@@ -3,6 +3,10 @@ package com.weit2nd.presentation.ui.foodspot.report
 sealed class FoodSpotReportIntent {
     data object GetFoodSpotCategories : FoodSpotReportIntent()
 
+    data class ChangeNameState(
+        val name: String,
+    ) : FoodSpotReportIntent()
+
     data class ChangeFoodTruckState(
         val isFoodTruck: Boolean,
     ) : FoodSpotReportIntent()

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
@@ -51,4 +51,6 @@ sealed class FoodSpotReportIntent {
     data class DeleteImage(
         val imgUri: String,
     ) : FoodSpotReportIntent()
+
+    data object ReportFoodSpot : FoodSpotReportIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
@@ -1,4 +1,7 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
 sealed class FoodSpotReportIntent {
+    data class ChangeFoodTruckState(
+        val isFoodTruck: Boolean,
+    ) : FoodSpotReportIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
@@ -1,11 +1,17 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
 sealed class FoodSpotReportIntent {
+    data object GetFoodSpotCategories : FoodSpotReportIntent()
+
     data class ChangeFoodTruckState(
         val isFoodTruck: Boolean,
     ) : FoodSpotReportIntent()
 
     data class ChangeOpenState(
         val isOpen: Boolean,
+    ) : FoodSpotReportIntent()
+
+    data class ChangeCategoryStatus(
+        val categoryStatus: CategoryStatus,
     ) : FoodSpotReportIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
@@ -1,5 +1,8 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
+import com.weit2nd.domain.model.spot.OperationHour
+import java.time.LocalTime
+
 sealed class FoodSpotReportIntent {
     data object GetFoodSpotCategories : FoodSpotReportIntent()
 
@@ -13,6 +16,23 @@ sealed class FoodSpotReportIntent {
 
     data class ChangeOpenState(
         val isOpen: Boolean,
+    ) : FoodSpotReportIntent()
+
+    data class ChangeOperationHourStatus(
+        val operationHourStatus: OperationHourStatus,
+    ) : FoodSpotReportIntent()
+
+    data class OpenTimePickerDialog(
+        val operationHour: OperationHour,
+        val isOpeningTime: Boolean,
+    ) : FoodSpotReportIntent()
+
+    data object CloseTimePickerDialog : FoodSpotReportIntent()
+
+    data class ChangeOperationTime(
+        val operationHour: OperationHour,
+        val isOpeningTime: Boolean,
+        val selectedTime: LocalTime,
     ) : FoodSpotReportIntent()
 
     data class ChangeCategoryStatus(

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
@@ -1,0 +1,4 @@
+package com.weit2nd.presentation.ui.foodspot.report
+
+sealed class FoodSpotReportIntent {
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportIntent.kt
@@ -1,5 +1,6 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
+import com.weit2nd.domain.model.search.Place
 import com.weit2nd.domain.model.spot.OperationHour
 import java.time.LocalTime
 
@@ -8,6 +9,12 @@ sealed class FoodSpotReportIntent {
 
     data class ChangeNameState(
         val name: String,
+    ) : FoodSpotReportIntent()
+
+    data object NavToSelectPlace : FoodSpotReportIntent()
+
+    data class SetPlace(
+        val place: Place,
     ) : FoodSpotReportIntent()
 
     data class ChangeFoodTruckState(

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
@@ -11,12 +11,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.Button
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.RadioButton
-import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -35,6 +36,10 @@ fun FoodSpotReportScreen(
     navToBack: () -> Unit,
 ) {
     val state = vm.collectAsState()
+
+    LaunchedEffect(Unit) {
+        vm.onCreate()
+    }
 
     Column(
         modifier =
@@ -101,15 +106,18 @@ fun FoodSpotReportScreen(
             }
 
             Column {
-                val categories = listOf("카테고리테스트입니다하나둘셋", "ㅁㅁㅁ", "ㅁㅁ", "ㅁ", "dfdfd")
                 Text(text = "음식 카테고리")
                 Text(text = "*최소 1개 이상 선택해야 합니다.", fontSize = 12.sp, fontStyle = FontStyle.Italic)
                 FlowRow(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    categories.forEach {
-                        SuggestionChip(onClick = { }, label = { Text(it) })
+                    state.value.categories.forEach { categoryStatus ->
+                        FilterChip(
+                            onClick = { vm.onClickCategory(categoryStatus) },
+                            selected = categoryStatus.isChecked,
+                            label = { Text(categoryStatus.category.name) },
+                        )
                     }
                 }
             }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
@@ -1,0 +1,120 @@
+package com.weit2nd.presentation.ui.foodspot.report
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.Button
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.weit2nd.presentation.R
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun FoodSpotReportScreen() {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(12.dp),
+        verticalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.Start,
+        ) {
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = "음식점이름",
+                onValueChange = {},
+            )
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Button(onClick = { }) {
+                    Text(text = "위치설정")
+                }
+                Text(text = "longitude\nlatitude")
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(text = "푸드트럭 여부")
+                Switch(checked = true, onCheckedChange = {})
+            }
+
+            Column {
+                Text(text = "현재 영업여부")
+                Row(
+                    modifier = Modifier.selectableGroup(),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(selected = true, onClick = { })
+                        Text(text = "영업중")
+                    }
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(selected = false, onClick = { })
+                        Text(text = "폐업")
+                    }
+                }
+            }
+
+            Column {
+                val categories = listOf("카테고리테스트입니다하나둘셋", "ㅁㅁㅁ", "ㅁㅁ", "ㅁ", "dfdfd")
+                Text(text = "음식 카테고리")
+                Text(text = "*최소 1개 이상 선택해야 합니다.", fontSize = 12.sp, fontStyle = FontStyle.Italic)
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    categories.forEach {
+                        SuggestionChip(onClick = { }, label = { Text(it) })
+                    }
+                }
+            }
+
+            Column {
+                Text(text = "음식점 사진")
+                Text(text = "*최대 3개까지 등록 가능합니다.", fontSize = 12.sp, fontStyle = FontStyle.Italic)
+                Image(
+                    painter = painterResource(id = R.drawable.ic_launcher_background),
+                    contentDescription = "",
+                )
+            }
+        }
+        Button(modifier = Modifier.fillMaxWidth(), onClick = { }) {
+            Text(text = "음식점 등록하기")
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun FoodSpotReportScreenPreview() {
+    FoodSpotReportScreen()
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
@@ -60,8 +60,8 @@ fun FoodSpotReportScreen(
         ) {
             TextField(
                 modifier = Modifier.fillMaxWidth(),
-                value = "음식점이름",
-                onValueChange = {},
+                value = state.value.name,
+                onValueChange = { vm.onNameValueChange(it) },
             )
 
             Row(

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -28,11 +29,17 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -172,10 +179,18 @@ private fun NameTextField(
     name: String,
     onNameValueChange: (String) -> Unit,
 ) {
+    var userInput by remember { mutableStateOf(TextFieldValue(name)) }
+
     TextField(
         modifier = Modifier.fillMaxWidth(),
-        value = name,
-        onValueChange = { onNameValueChange(it) },
+        value = userInput,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+        placeholder = { Text(text = "음식점 이름") },
+        onValueChange = { newValue ->
+            userInput = newValue
+            onNameValueChange(newValue.text)
+        },
+        singleLine = true,
     )
 }
 

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
@@ -24,11 +24,18 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.weit2nd.presentation.R
+import org.orbitmvi.orbit.compose.collectAsState
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun FoodSpotReportScreen(navToBack: () -> Unit) {
+fun FoodSpotReportScreen(
+    vm: FoodSpotReportViewModel = hiltViewModel(),
+    navToBack: () -> Unit,
+) {
+    val state = vm.collectAsState()
+
     Column(
         modifier =
             Modifier
@@ -61,7 +68,10 @@ fun FoodSpotReportScreen(navToBack: () -> Unit) {
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 Text(text = "푸드트럭 여부")
-                Switch(checked = true, onCheckedChange = {})
+                Switch(
+                    checked = state.value.isFoodTruck,
+                    onCheckedChange = { vm.onSwitchCheckedChange(it) },
+                )
             }
 
             Column {

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
@@ -28,7 +28,7 @@ import com.weit2nd.presentation.R
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun FoodSpotReportScreen() {
+fun FoodSpotReportScreen(navToBack: () -> Unit) {
     Column(
         modifier =
             Modifier
@@ -116,5 +116,5 @@ fun FoodSpotReportScreen() {
 @Preview(showBackground = true)
 @Composable
 fun FoodSpotReportScreenPreview() {
-    FoodSpotReportScreen()
+    FoodSpotReportScreen {}
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
@@ -274,9 +274,9 @@ private fun OperationTimeSetting(
         if (isDialogOpen) {
             TimePickerDialog(
                 selectedTime = if (isOpeningTime) operationHour.openingHours else operationHour.closingHours,
-                operationHour = operationHour,
-                isOpeningTime = isOpeningTime,
-                onClickConfirm = onSelectTime,
+                onClickConfirm = { selectedTime ->
+                    onSelectTime(operationHour, isOpeningTime, selectedTime)
+                },
                 onDismissRequest = onCloseDialog,
             )
         }
@@ -302,7 +302,12 @@ private fun DayOfWeekSelector(
         operationHours.forEach { operationHourStatus ->
             FilterChip(
                 selected = operationHourStatus.isSelected,
-                onClick = { onClickDayOfWeekBtn(operationHourStatus, operationHourStatus.isSelected.not()) },
+                onClick = {
+                    onClickDayOfWeekBtn(
+                        operationHourStatus,
+                        operationHourStatus.isSelected.not(),
+                    )
+                },
                 label = { Text(text = dayOfWeekTitle[operationHourStatus.operationHour.dayOfWeek.value - 1]) },
             )
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
@@ -1,5 +1,6 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -30,6 +31,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
@@ -57,10 +59,19 @@ fun FoodSpotReportScreen(
     navController: NavController,
 ) {
     val state = vm.collectAsState()
+    val context = LocalContext.current
     vm.collectSideEffect { sideEffect ->
         when (sideEffect) {
             FoodSpotReportSideEffect.NavToSelectPlace -> {
                 navToSelectPlace()
+            }
+
+            is FoodSpotReportSideEffect.ShowToast -> {
+                Toast.makeText(context, sideEffect.message, Toast.LENGTH_SHORT).show()
+            }
+
+            FoodSpotReportSideEffect.ReportSuccess -> {
+                navToBack()
             }
         }
     }
@@ -138,7 +149,11 @@ fun FoodSpotReportScreen(
                 )
             }
         }
-        Button(modifier = Modifier.fillMaxWidth(), onClick = { }) {
+        Button(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = { vm.onClickReportBtn() },
+            enabled = state.value.isLoading.not(),
+        ) {
             Text(text = "음식점 등록하기")
         }
     }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
@@ -264,7 +264,7 @@ private fun OpenCloseSelector(
 private fun OperationTimeSetting(
     operationHours: List<OperationHourStatus>,
     dialogStatus: TimePickerDialogStatus,
-    onClickDayOfWeekBtn: (OperationHourStatus) -> Unit,
+    onClickDayOfWeekBtn: (OperationHourStatus, isSelected: Boolean) -> Unit,
     onSelectTime: (operationHour: OperationHour, isOpeningTime: Boolean, selectedTime: LocalTime) -> Unit,
     onCloseDialog: () -> Unit,
     onClickEditTimeBtn: (operationHour: OperationHour, isOpeningTime: Boolean) -> Unit,
@@ -292,7 +292,7 @@ private fun OperationTimeSetting(
 @Composable
 private fun DayOfWeekSelector(
     operationHours: List<OperationHourStatus>,
-    onClickDayOfWeekBtn: (OperationHourStatus) -> Unit,
+    onClickDayOfWeekBtn: (OperationHourStatus, isSelected: Boolean) -> Unit,
     dayOfWeekTitle: List<String>,
 ) {
     Row(
@@ -302,7 +302,7 @@ private fun DayOfWeekSelector(
         operationHours.forEach { operationHourStatus ->
             FilterChip(
                 selected = operationHourStatus.isSelected,
-                onClick = { onClickDayOfWeekBtn(operationHourStatus) },
+                onClick = { onClickDayOfWeekBtn(operationHourStatus, operationHourStatus.isSelected.not()) },
                 label = { Text(text = dayOfWeekTitle[operationHourStatus.operationHour.dayOfWeek.value - 1]) },
             )
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
@@ -258,7 +258,7 @@ private fun OperationTimeSetting(
     dialogStatus.apply {
         if (isDialogOpen) {
             TimePickerDialog(
-                selectedTime = operationHour.openingHours,
+                selectedTime = if (isOpeningTime) operationHour.openingHours else operationHour.closingHours,
                 operationHour = operationHour,
                 isOpeningTime = isOpeningTime,
                 onClickConfirm = onSelectTime,
@@ -324,11 +324,14 @@ private fun OperationTime(
             },
     ) {
         val hours =
-            if (isOpeningTime) {
-                operationHourStatus.operationHour.openingHours
-            } else {
-                operationHourStatus.operationHour.closingHours
+            operationHourStatus.operationHour.run {
+                if (isOpeningTime) {
+                    openingHours
+                } else {
+                    closingHours
+                }
             }
+
         Text(
             text = hours.format(DateTimeFormatter.ofPattern("HH:mm")),
             textDecoration = TextDecoration.Underline,

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
@@ -1,6 +1,6 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
-import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -9,9 +9,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Button
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -20,13 +25,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.weit2nd.presentation.R
+import com.weit2nd.presentation.ui.common.CancelableImage
+import com.weit2nd.presentation.ui.foodspot.report.FoodSpotReportViewModel.Companion.IMAGE_MAX_SIZE
 import org.orbitmvi.orbit.compose.collectAsState
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -125,10 +131,28 @@ fun FoodSpotReportScreen(
             Column {
                 Text(text = "음식점 사진")
                 Text(text = "*최대 3개까지 등록 가능합니다.", fontSize = 12.sp, fontStyle = FontStyle.Italic)
-                Image(
-                    painter = painterResource(id = R.drawable.ic_launcher_background),
-                    contentDescription = "",
-                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    state.value.reportImages.forEach { imgUri ->
+                        CancelableImage(
+                            modifier = Modifier.size(100.dp),
+                            imgUri = imgUri,
+                            onDeleteImage = vm::onDeleteImage,
+                        )
+                    }
+                    if (state.value.reportImages.size < IMAGE_MAX_SIZE) {
+                        IconButton(
+                            modifier = Modifier.size(100.dp).background(Color.LightGray),
+                            onClick = vm::onClickSelectImagesBtn,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Add,
+                                contentDescription = "select_image",
+                            )
+                        }
+                    }
+                }
             }
         }
         Button(modifier = Modifier.fillMaxWidth(), onClick = { }) {

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportScreen.kt
@@ -82,13 +82,19 @@ fun FoodSpotReportScreen(
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        RadioButton(selected = true, onClick = { })
+                        RadioButton(
+                            selected = state.value.isOpen,
+                            onClick = { vm.onClickIsOpenBtn(true) },
+                        )
                         Text(text = "영업중")
                     }
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        RadioButton(selected = false, onClick = { })
+                        RadioButton(
+                            selected = state.value.isOpen.not(),
+                            onClick = { vm.onClickIsOpenBtn(false) },
+                        )
                         Text(text = "폐업")
                     }
                 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportSideEffect.kt
@@ -1,0 +1,4 @@
+package com.weit2nd.presentation.ui.foodspot.report
+
+sealed class FoodSpotReportSideEffect {
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportSideEffect.kt
@@ -1,4 +1,5 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
 sealed class FoodSpotReportSideEffect {
+    data object NavToSelectPlace : FoodSpotReportSideEffect()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportSideEffect.kt
@@ -2,4 +2,10 @@ package com.weit2nd.presentation.ui.foodspot.report
 
 sealed class FoodSpotReportSideEffect {
     data object NavToSelectPlace : FoodSpotReportSideEffect()
+
+    data class ShowToast(
+        val message: String,
+    ) : FoodSpotReportSideEffect()
+
+    data object ReportSuccess : FoodSpotReportSideEffect()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
@@ -1,11 +1,13 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
+import com.weit2nd.domain.model.search.Place
 import com.weit2nd.domain.model.spot.FoodSpotCategory
 import com.weit2nd.domain.model.spot.OperationHour
 import java.time.DayOfWeek
 
 data class FoodSpotReportState(
     val name: String = "",
+    val place: Place? = null,
     val isFoodTruck: Boolean = false,
     val isOpen: Boolean = true,
     val operationHours: List<OperationHourStatus> =

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
@@ -19,6 +19,7 @@ data class FoodSpotReportState(
     val dialogStatus: TimePickerDialogStatus = TimePickerDialogStatus(),
     val categories: List<CategoryStatus> = emptyList(),
     val reportImages: List<String> = emptyList(),
+    val isLoading: Boolean = false,
 )
 
 data class CategoryStatus(

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
@@ -4,6 +4,7 @@ import com.weit2nd.domain.model.search.Place
 import com.weit2nd.domain.model.spot.FoodSpotCategory
 import com.weit2nd.domain.model.spot.OperationHour
 import java.time.DayOfWeek
+import java.time.LocalTime
 
 data class FoodSpotReportState(
     val name: String = "",
@@ -13,7 +14,11 @@ data class FoodSpotReportState(
     val operationHours: List<OperationHourStatus> =
         DayOfWeek.entries.map { dayOfWeek ->
             OperationHourStatus(
-                OperationHour(dayOfWeek = dayOfWeek),
+                OperationHour(
+                    dayOfWeek = dayOfWeek,
+                    openingHours = LocalTime.of(9, 0),
+                    closingHours = LocalTime.of(18, 0),
+                ),
             )
         },
     val dialogStatus: TimePickerDialogStatus = TimePickerDialogStatus(),
@@ -32,8 +37,15 @@ data class OperationHourStatus(
     val isSelected: Boolean = true,
 )
 
+private val operationHourDummy =
+    OperationHour(
+        dayOfWeek = DayOfWeek.MONDAY,
+        openingHours = LocalTime.of(9, 0),
+        closingHours = LocalTime.of(18, 0),
+    )
+
 data class TimePickerDialogStatus(
     val isDialogOpen: Boolean = false,
-    val operationHour: OperationHour = OperationHour(DayOfWeek.MONDAY),
+    val operationHour: OperationHour = operationHourDummy,
     val isOpeningTime: Boolean = true,
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
@@ -2,4 +2,5 @@ package com.weit2nd.presentation.ui.foodspot.report
 
 data class FoodSpotReportState(
     val name: String = "",
+    val isFoodTruck: Boolean = false,
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
@@ -7,6 +7,7 @@ data class FoodSpotReportState(
     val isFoodTruck: Boolean = false,
     val isOpen: Boolean = true,
     val categories: List<CategoryStatus> = emptyList(),
+    val reportImages: List<String> = emptyList(),
 )
 
 data class CategoryStatus(

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
@@ -3,4 +3,5 @@ package com.weit2nd.presentation.ui.foodspot.report
 data class FoodSpotReportState(
     val name: String = "",
     val isFoodTruck: Boolean = false,
+    val isOpen: Boolean = true,
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
@@ -1,0 +1,5 @@
+package com.weit2nd.presentation.ui.foodspot.report
+
+data class FoodSpotReportState(
+    val name: String = "",
+)

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
@@ -1,11 +1,20 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
 import com.weit2nd.domain.model.spot.FoodSpotCategory
+import com.weit2nd.domain.model.spot.OperationHour
+import java.time.DayOfWeek
 
 data class FoodSpotReportState(
     val name: String = "",
     val isFoodTruck: Boolean = false,
     val isOpen: Boolean = true,
+    val operationHours: List<OperationHourStatus> =
+        DayOfWeek.entries.map { dayOfWeek ->
+            OperationHourStatus(
+                OperationHour(dayOfWeek = dayOfWeek),
+            )
+        },
+    val dialogStatus: TimePickerDialogStatus = TimePickerDialogStatus(),
     val categories: List<CategoryStatus> = emptyList(),
     val reportImages: List<String> = emptyList(),
 )
@@ -13,4 +22,15 @@ data class FoodSpotReportState(
 data class CategoryStatus(
     val category: FoodSpotCategory,
     val isChecked: Boolean = false,
+)
+
+data class OperationHourStatus(
+    val operationHour: OperationHour,
+    val isSelected: Boolean = true,
+)
+
+data class TimePickerDialogStatus(
+    val isDialogOpen: Boolean = false,
+    val operationHour: OperationHour = OperationHour(DayOfWeek.MONDAY),
+    val isOpeningTime: Boolean = true,
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportState.kt
@@ -1,7 +1,15 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
+import com.weit2nd.domain.model.spot.FoodSpotCategory
+
 data class FoodSpotReportState(
     val name: String = "",
     val isFoodTruck: Boolean = false,
     val isOpen: Boolean = true,
+    val categories: List<CategoryStatus> = emptyList(),
+)
+
+data class CategoryStatus(
+    val category: FoodSpotCategory,
+    val isChecked: Boolean = false,
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
@@ -1,5 +1,6 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
+import com.weit2nd.domain.model.search.Place
 import com.weit2nd.domain.model.spot.FoodSpotCategory
 import com.weit2nd.domain.model.spot.OperationHour
 import com.weit2nd.domain.usecase.pickimage.PickMultipleImagesUseCase
@@ -22,6 +23,14 @@ class FoodSpotReportViewModel @Inject constructor(
 
     fun onNameValueChange(name: String) {
         FoodSpotReportIntent.ChangeNameState(name).post()
+    }
+
+    fun onClickSetPlaceBtn() {
+        FoodSpotReportIntent.NavToSelectPlace.post()
+    }
+
+    fun onSelectPlace(place: Place) {
+        FoodSpotReportIntent.SetPlace(place).post()
     }
 
     fun onSwitchCheckedChange(isChecked: Boolean) {
@@ -90,6 +99,18 @@ class FoodSpotReportViewModel @Inject constructor(
                     reduce {
                         state.copy(
                             name = name,
+                        )
+                    }
+                }
+
+                FoodSpotReportIntent.NavToSelectPlace -> {
+                    postSideEffect(FoodSpotReportSideEffect.NavToSelectPlace)
+                }
+
+                is FoodSpotReportIntent.SetPlace -> {
+                    reduce {
+                        state.copy(
+                            place = place,
                         )
                     }
                 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
@@ -1,0 +1,12 @@
+package com.weit2nd.presentation.ui.foodspot.report
+
+import com.weit2nd.presentation.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.orbitmvi.orbit.viewmodel.container
+import javax.inject.Inject
+
+@HiltViewModel
+class FoodSpotReportViewModel @Inject constructor() : BaseViewModel<FoodSpotReportState, FoodSpotReportSideEffect>() {
+    override val container =
+        container<FoodSpotReportState, FoodSpotReportSideEffect>(FoodSpotReportState())
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
@@ -46,8 +46,15 @@ class FoodSpotReportViewModel @Inject constructor(
         FoodSpotReportIntent.ChangeOpenState(isOpen).post()
     }
 
-    fun onClickDayOfWeekBtn(operationHourStatus: OperationHourStatus) {
-        FoodSpotReportIntent.ChangeOperationHourStatus(operationHourStatus).post()
+    fun onClickDayOfWeekBtn(
+        operationHourStatus: OperationHourStatus,
+        isSelected: Boolean,
+    ) {
+        FoodSpotReportIntent
+            .ChangeOperationHourStatus(
+                operationHourStatus,
+                isSelected,
+            ).post()
     }
 
     fun onClickEditTimeBtn(
@@ -146,7 +153,7 @@ class FoodSpotReportViewModel @Inject constructor(
                             operationHours =
                                 state.operationHours.map { status ->
                                     if (status == operationHourStatus) {
-                                        status.copy(isSelected = status.isSelected.not())
+                                        status.copy(isSelected = isSelected)
                                     } else {
                                         status
                                     }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
@@ -14,6 +14,10 @@ class FoodSpotReportViewModel @Inject constructor() : BaseViewModel<FoodSpotRepo
         FoodSpotReportIntent.ChangeFoodTruckState(isChecked).post()
     }
 
+    fun onClickIsOpenBtn(isOpen: Boolean) {
+        FoodSpotReportIntent.ChangeOpenState(isOpen).post()
+    }
+
     private fun FoodSpotReportIntent.post() =
         intent {
             when (this@post) {
@@ -21,6 +25,14 @@ class FoodSpotReportViewModel @Inject constructor() : BaseViewModel<FoodSpotRepo
                     reduce {
                         state.copy(
                             isFoodTruck = isFoodTruck,
+                        )
+                    }
+                }
+
+                is FoodSpotReportIntent.ChangeOpenState -> {
+                    reduce {
+                        state.copy(
+                            isOpen = isOpen,
                         )
                     }
                 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
@@ -1,13 +1,16 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
 import com.weit2nd.domain.model.spot.FoodSpotCategory
+import com.weit2nd.domain.usecase.pickimage.PickMultipleImagesUseCase
 import com.weit2nd.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
 @HiltViewModel
-class FoodSpotReportViewModel @Inject constructor() : BaseViewModel<FoodSpotReportState, FoodSpotReportSideEffect>() {
+class FoodSpotReportViewModel @Inject constructor(
+    private val pickMultipleImagesUseCase: PickMultipleImagesUseCase,
+) : BaseViewModel<FoodSpotReportState, FoodSpotReportSideEffect>() {
     override val container =
         container<FoodSpotReportState, FoodSpotReportSideEffect>(FoodSpotReportState())
 
@@ -25,6 +28,14 @@ class FoodSpotReportViewModel @Inject constructor() : BaseViewModel<FoodSpotRepo
 
     fun onClickCategory(categoryStatus: CategoryStatus) {
         FoodSpotReportIntent.ChangeCategoryStatus(categoryStatus).post()
+    }
+
+    fun onClickSelectImagesBtn() {
+        FoodSpotReportIntent.SelectImage.post()
+    }
+
+    fun onDeleteImage(imgUri: String) {
+        FoodSpotReportIntent.DeleteImage(imgUri).post()
     }
 
     private fun FoodSpotReportIntent.post() =
@@ -76,6 +87,28 @@ class FoodSpotReportViewModel @Inject constructor() : BaseViewModel<FoodSpotRepo
                         )
                     }
                 }
+
+                FoodSpotReportIntent.SelectImage -> {
+                    val selectedImages =
+                        pickMultipleImagesUseCase.invoke(maximumSelect = IMAGE_MAX_SIZE - state.reportImages.size)
+                    reduce {
+                        state.copy(
+                            reportImages = (state.reportImages + selectedImages).toSet().toList(),
+                        )
+                    }
+                }
+
+                is FoodSpotReportIntent.DeleteImage -> {
+                    reduce {
+                        state.copy(
+                            reportImages = state.reportImages.filterNot { it == imgUri },
+                        )
+                    }
+                }
             }
         }
+
+    companion object {
+        const val IMAGE_MAX_SIZE = 3
+    }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
@@ -1,5 +1,6 @@
 package com.weit2nd.presentation.ui.foodspot.report
 
+import com.weit2nd.domain.model.spot.FoodSpotCategory
 import com.weit2nd.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.viewmodel.container
@@ -10,6 +11,10 @@ class FoodSpotReportViewModel @Inject constructor() : BaseViewModel<FoodSpotRepo
     override val container =
         container<FoodSpotReportState, FoodSpotReportSideEffect>(FoodSpotReportState())
 
+    fun onCreate() {
+        FoodSpotReportIntent.GetFoodSpotCategories.post()
+    }
+
     fun onSwitchCheckedChange(isChecked: Boolean) {
         FoodSpotReportIntent.ChangeFoodTruckState(isChecked).post()
     }
@@ -18,9 +23,29 @@ class FoodSpotReportViewModel @Inject constructor() : BaseViewModel<FoodSpotRepo
         FoodSpotReportIntent.ChangeOpenState(isOpen).post()
     }
 
+    fun onClickCategory(categoryStatus: CategoryStatus) {
+        FoodSpotReportIntent.ChangeCategoryStatus(categoryStatus).post()
+    }
+
     private fun FoodSpotReportIntent.post() =
         intent {
             when (this@post) {
+                FoodSpotReportIntent.GetFoodSpotCategories -> {
+                    // todo 카테고리 조회 api 연결
+                    val categories =
+                        listOf(
+                            FoodSpotCategory(1, "붕어빵"),
+                            FoodSpotCategory(1, "붕어빵1"),
+                            FoodSpotCategory(1, "붕어빵22"),
+                            FoodSpotCategory(1, "붕어빵333"),
+                        )
+                    reduce {
+                        state.copy(
+                            categories = categories.map { CategoryStatus(it) },
+                        )
+                    }
+                }
+
                 is FoodSpotReportIntent.ChangeFoodTruckState -> {
                     reduce {
                         state.copy(
@@ -33,6 +58,21 @@ class FoodSpotReportViewModel @Inject constructor() : BaseViewModel<FoodSpotRepo
                     reduce {
                         state.copy(
                             isOpen = isOpen,
+                        )
+                    }
+                }
+
+                is FoodSpotReportIntent.ChangeCategoryStatus -> {
+                    reduce {
+                        state.copy(
+                            categories =
+                                state.categories.map { category ->
+                                    if (category == categoryStatus) {
+                                        category.copy(isChecked = category.isChecked.not())
+                                    } else {
+                                        category
+                                    }
+                                },
                         )
                     }
                 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
@@ -9,4 +9,21 @@ import javax.inject.Inject
 class FoodSpotReportViewModel @Inject constructor() : BaseViewModel<FoodSpotReportState, FoodSpotReportSideEffect>() {
     override val container =
         container<FoodSpotReportState, FoodSpotReportSideEffect>(FoodSpotReportState())
+
+    fun onSwitchCheckedChange(isChecked: Boolean) {
+        FoodSpotReportIntent.ChangeFoodTruckState(isChecked).post()
+    }
+
+    private fun FoodSpotReportIntent.post() =
+        intent {
+            when (this@post) {
+                is FoodSpotReportIntent.ChangeFoodTruckState -> {
+                    reduce {
+                        state.copy(
+                            isFoodTruck = isFoodTruck,
+                        )
+                    }
+                }
+            }
+        }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/FoodSpotReportViewModel.kt
@@ -18,6 +18,10 @@ class FoodSpotReportViewModel @Inject constructor(
         FoodSpotReportIntent.GetFoodSpotCategories.post()
     }
 
+    fun onNameValueChange(name: String) {
+        FoodSpotReportIntent.ChangeNameState(name).post()
+    }
+
     fun onSwitchCheckedChange(isChecked: Boolean) {
         FoodSpotReportIntent.ChangeFoodTruckState(isChecked).post()
     }
@@ -53,6 +57,14 @@ class FoodSpotReportViewModel @Inject constructor(
                     reduce {
                         state.copy(
                             categories = categories.map { CategoryStatus(it) },
+                        )
+                    }
+                }
+
+                is FoodSpotReportIntent.ChangeNameState -> {
+                    reduce {
+                        state.copy(
+                            name = name,
                         )
                     }
                 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/TimePickerDialog.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/TimePickerDialog.kt
@@ -1,0 +1,89 @@
+package com.weit2nd.presentation.ui.foodspot.report
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.weit2nd.domain.model.spot.OperationHour
+import java.time.LocalTime
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TimePickerDialog(
+    modifier: Modifier = Modifier,
+    selectedTime: LocalTime,
+    operationHour: OperationHour,
+    isOpeningTime: Boolean,
+    onDismissRequest: () -> Unit,
+    onClickConfirm: (
+        operationHour: OperationHour,
+        isOpeningTime: Boolean,
+        selectedTime: LocalTime,
+    ) -> Unit,
+) {
+    val timePickerState =
+        rememberTimePickerState(
+            initialHour = selectedTime.hour,
+            initialMinute = selectedTime.minute,
+            is24Hour = true,
+        )
+
+    Dialog(
+        onDismissRequest = { onDismissRequest() },
+    ) {
+        Column(
+            modifier =
+                modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color.White)
+                    .padding(12.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            TimePicker(
+                modifier = Modifier.fillMaxWidth(),
+                state = timePickerState,
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Button(onClick = { onDismissRequest() }) {
+                    Text(text = "취소")
+                }
+
+                Button(
+                    onClick = {
+                        onClickConfirm(
+                            operationHour,
+                            isOpeningTime,
+                            LocalTime.of(
+                                timePickerState.hour,
+                                timePickerState.minute,
+                            ),
+                        )
+                    },
+                ) {
+                    Text(text = "확인")
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/TimePickerDialog.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/report/TimePickerDialog.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import com.weit2nd.domain.model.spot.OperationHour
 import java.time.LocalTime
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -27,14 +26,8 @@ import java.time.LocalTime
 fun TimePickerDialog(
     modifier: Modifier = Modifier,
     selectedTime: LocalTime,
-    operationHour: OperationHour,
-    isOpeningTime: Boolean,
     onDismissRequest: () -> Unit,
-    onClickConfirm: (
-        operationHour: OperationHour,
-        isOpeningTime: Boolean,
-        selectedTime: LocalTime,
-    ) -> Unit,
+    onClickConfirm: (selectedTime: LocalTime) -> Unit,
 ) {
     val timePickerState =
         rememberTimePickerState(
@@ -72,8 +65,6 @@ fun TimePickerDialog(
                 Button(
                     onClick = {
                         onClickConfirm(
-                            operationHour,
-                            isOpeningTime,
                             LocalTime.of(
                                 timePickerState.hour,
                                 timePickerState.minute,

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/home/HomeIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/home/HomeIntent.kt
@@ -1,0 +1,5 @@
+package com.weit2nd.presentation.ui.home
+
+sealed class HomeIntent {
+    data object NavToFoodSpotReport : HomeIntent()
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/home/HomeScreen.kt
@@ -2,26 +2,53 @@ package com.weit2nd.presentation.ui.home
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.weit2nd.presentation.ui.map.MapScreen
 import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
-fun HomeScreen(vm: HomeViewModel = hiltViewModel()) {
+fun HomeScreen(
+    vm: HomeViewModel = hiltViewModel(),
+    navToFoodSpotReport: () -> Unit,
+) {
     val state = vm.collectAsState()
+    vm.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            HomeSideEffect.NavToFoodSpotReport -> navToFoodSpotReport()
+        }
+    }
     Surface {
         Box(
-            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxSize(),
         ) {
             Text(
                 text = state.value.user.name,
             )
             MapScreen(modifier = Modifier.fillMaxSize())
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(16.dp),
+            ) {
+                FloatingActionButton(
+                    onClick = vm::onClickReportBtn,
+                ) {
+                    Icon(Icons.Filled.Add, "report food-spot")
+                }
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/home/HomeSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/home/HomeSideEffect.kt
@@ -1,3 +1,5 @@
 package com.weit2nd.presentation.ui.home
 
-sealed class HomeSideEffect
+sealed class HomeSideEffect  {
+    data object NavToFoodSpotReport : HomeSideEffect()
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/home/HomeViewModel.kt
@@ -22,4 +22,17 @@ class HomeViewModel @Inject constructor(
                     ),
             ),
         )
+
+    fun onClickReportBtn() {
+        HomeIntent.NavToFoodSpotReport.post()
+    }
+
+    private fun HomeIntent.post() =
+        intent {
+            when (this@post) {
+                HomeIntent.NavToFoodSpotReport -> {
+                    postSideEffect(HomeSideEffect.NavToFoodSpotReport)
+                }
+            }
+        }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/SelectPlaceIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/SelectPlaceIntent.kt
@@ -1,9 +1,15 @@
 package com.weit2nd.presentation.ui.select.place
 
+import com.weit2nd.domain.model.search.Place
+
 sealed class SelectPlaceIntent {
     data object SearchPlace : SelectPlaceIntent()
 
     data class StoreSearchWord(
         val input: String,
+    ) : SelectPlaceIntent()
+
+    data class SelectPlace(
+        val place: Place,
     ) : SelectPlaceIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/SelectPlaceSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/SelectPlaceSideEffect.kt
@@ -1,3 +1,9 @@
 package com.weit2nd.presentation.ui.select.place
 
-sealed class SelectPlaceSideEffect
+import com.weit2nd.domain.model.search.Place
+
+sealed class SelectPlaceSideEffect {
+    data class SelectPlace(
+        val place: Place,
+    ) : SelectPlaceSideEffect()
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/SelectPlaceViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/SelectPlaceViewModel.kt
@@ -1,5 +1,6 @@
 package com.weit2nd.presentation.ui.select.place
 
+import com.weit2nd.domain.model.search.Place
 import com.weit2nd.domain.usecase.search.SearchPlacesWithWordUseCase
 import com.weit2nd.presentation.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,6 +20,10 @@ class SelectPlaceViewModel @Inject constructor(
 
     fun onLocationSearch() {
         SelectPlaceIntent.SearchPlace.post()
+    }
+
+    fun onClickPlace(place: Place)  {
+        SelectPlaceIntent.SelectPlace(place).post()
     }
 
     private fun SelectPlaceIntent.post() =
@@ -42,6 +47,10 @@ class SelectPlaceViewModel @Inject constructor(
                             )
                         }
                     }
+                }
+
+                is SelectPlaceIntent.SelectPlace -> {
+                    postSideEffect(SelectPlaceSideEffect.SelectPlace(place))
                 }
             }
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectLocationMapIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectLocationMapIntent.kt
@@ -3,6 +3,7 @@ package com.weit2nd.presentation.ui.select.place.map
 import androidx.compose.ui.unit.IntOffset
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.LatLng
+import com.weit2nd.domain.model.search.Place
 
 sealed class SelectLocationMapIntent {
     data class StoreMap(
@@ -21,5 +22,9 @@ sealed class SelectLocationMapIntent {
 
     data class RequestCameraMove(
         val position: LatLng,
+    ) : SelectLocationMapIntent()
+
+    data class SelectPlace(
+        val place: Place,
     ) : SelectLocationMapIntent()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectLocationMapSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectLocationMapSideEffect.kt
@@ -2,10 +2,15 @@ package com.weit2nd.presentation.ui.select.place.map
 
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.LatLng
+import com.weit2nd.domain.model.search.Place
 
 sealed class SelectLocationMapSideEffect {
     data class MoveCamera(
         val map: KakaoMap,
         val position: LatLng,
+    ) : SelectLocationMapSideEffect()
+
+    data class SelectPlace(
+        val place: Place,
     ) : SelectLocationMapSideEffect()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectLocationMapViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectLocationMapViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.LatLng
 import com.weit2nd.domain.model.Coordinate
+import com.weit2nd.domain.model.search.Place
 import com.weit2nd.domain.usecase.search.SearchLocationWithCoordinateUseCase
 import com.weit2nd.presentation.base.BaseViewModel
 import com.weit2nd.presentation.navigation.SelectPlaceMapRoutes
@@ -55,6 +56,16 @@ class SelectLocationMapViewModel @Inject constructor(
 
     fun onClickCurrentPositionBtn(currentPosition: LatLng) {
         SelectLocationMapIntent.RequestCameraMove(currentPosition).post()
+    }
+
+    fun onClickSelectPlaceBtn() {
+        /*todo 좌표로 주소받는 api 연결 후 state 정돈 필요!
+        Location이 아닌 Place로 통일*/
+        val place =
+            container.stateFlow.value.location.coordinate.run {
+                Place("test", "test", "test", longitude = longitude, latitude = latitude, "")
+            }
+        SelectLocationMapIntent.SelectPlace(place).post()
     }
 
     private fun SelectLocationMapIntent.post() =
@@ -118,6 +129,10 @@ class SelectLocationMapViewModel @Inject constructor(
                     state.map?.let { map ->
                         postSideEffect(SelectLocationMapSideEffect.MoveCamera(map, position))
                     }
+                }
+
+                is SelectLocationMapIntent.SelectPlace -> {
+                    postSideEffect(SelectLocationMapSideEffect.SelectPlace(place))
                 }
             }
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectLocationMapViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectLocationMapViewModel.kt
@@ -8,7 +8,7 @@ import com.kakao.vectormap.LatLng
 import com.weit2nd.domain.model.Coordinate
 import com.weit2nd.domain.usecase.search.SearchLocationWithCoordinateUseCase
 import com.weit2nd.presentation.base.BaseViewModel
-import com.weit2nd.presentation.navigation.SelectLocationMapRoutes
+import com.weit2nd.presentation.navigation.SelectPlaceMapRoutes
 import com.weit2nd.presentation.navigation.dto.CoordinateDTO
 import com.weit2nd.presentation.navigation.dto.toCoordinate
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -29,7 +29,7 @@ class SelectLocationMapViewModel @Inject constructor(
                     checkNotNull(
                         savedStateHandle
                             .get<CoordinateDTO>(
-                                SelectLocationMapRoutes.INITIAL_POSITION_KEY,
+                                SelectPlaceMapRoutes.INITIAL_POSITION_KEY,
                             )?.toCoordinate(),
                     ),
             ),

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectPlaceMapScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectPlaceMapScreen.kt
@@ -42,15 +42,19 @@ import com.kakao.vectormap.MapLifeCycleCallback
 import com.kakao.vectormap.MapView
 import com.kakao.vectormap.camera.CameraUpdateFactory
 import com.weit2nd.domain.model.Location
+import com.weit2nd.domain.model.search.Place
 import com.weit2nd.presentation.ui.common.currentposition.CurrentPositionBtn
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
-fun SelectPlaceMapScreen(vm: SelectLocationMapViewModel = hiltViewModel()) {
+fun SelectPlaceMapScreen(
+    vm: SelectLocationMapViewModel = hiltViewModel(),
+    onSelectPlace: (Place) -> Unit,
+) {
     val state = vm.collectAsState()
     vm.collectSideEffect { sideEffect ->
-        handleSideEffects(sideEffect)
+        handleSideEffects(sideEffect, onSelectPlace)
     }
     val context = LocalContext.current
     val mapView =
@@ -63,7 +67,13 @@ fun SelectPlaceMapScreen(vm: SelectLocationMapViewModel = hiltViewModel()) {
                         onCameraMoveStart = vm::onCameraMoveStart,
                         onCameraMoveEnd = vm::onCameraMoveEnd,
                         selectMarkerOffset = state.value.selectMarkerOffset,
-                        position = state.value.initialPosition.run { LatLng.from(latitude, longitude) },
+                        position =
+                            state.value.initialPosition.run {
+                                LatLng.from(
+                                    latitude,
+                                    longitude,
+                                )
+                            },
                     ),
                 )
             }
@@ -115,16 +125,23 @@ fun SelectPlaceMapScreen(vm: SelectLocationMapViewModel = hiltViewModel()) {
                     .padding(16.dp),
             isLoading = state.value.isLoading,
             location = state.value.location,
-            onClick = {},
+            onClick = vm::onClickSelectPlaceBtn,
         )
     }
 }
 
-private fun handleSideEffects(sideEffect: SelectLocationMapSideEffect) {
+private fun handleSideEffects(
+    sideEffect: SelectLocationMapSideEffect,
+    onSelectPlace: (Place) -> Unit,
+) {
     when (sideEffect) {
         is SelectLocationMapSideEffect.MoveCamera -> {
             val cameraUpdate = CameraUpdateFactory.newCenterPosition(sideEffect.position)
             sideEffect.map.moveCamera(cameraUpdate)
+        }
+
+        is SelectLocationMapSideEffect.SelectPlace -> {
+            onSelectPlace(sideEffect.place)
         }
     }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectPlaceMapScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectPlaceMapScreen.kt
@@ -47,7 +47,7 @@ import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
-fun SelectLocationMapScreen(vm: SelectLocationMapViewModel = hiltViewModel()) {
+fun SelectPlaceMapScreen(vm: SelectLocationMapViewModel = hiltViewModel()) {
     val state = vm.collectAsState()
     vm.collectSideEffect { sideEffect ->
         handleSideEffects(sideEffect)

--- a/presentation/src/main/java/com/weit2nd/presentation/util/ObserveSavedState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/util/ObserveSavedState.kt
@@ -1,0 +1,28 @@
+package com.weit2nd.presentation.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.lifecycle.LifecycleOwner
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+@Composable
+fun <T : Any> NavController.ObserveSavedState(
+    lifecycleOwner: LifecycleOwner,
+    key: String,
+    observe: (T) -> Unit,
+) {
+    val previousValue = remember { mutableStateOf<T?>(null) }
+    this
+        .currentBackStackEntryAsState()
+        .value
+        ?.savedStateHandle
+        ?.getLiveData<T>(key)
+        ?.observe(lifecycleOwner) { newValue ->
+            if (previousValue.value != newValue) {
+                previousValue.value = newValue
+                observe(newValue)
+            }
+        }
+}


### PR DESCRIPTION
### 개요
- 음식점 리포트 화면 (프리스타일 ver)
### 변경사항
- 음식점 리포트 화면 생성
- CancelableImage 생성
### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-101) 

### 리뷰어에게 하고 싶은 말
- 양이 진짜 정말 많아서 혹시 코드 설명 필요하면 언제든 게더로 불러주세요
- 지도로 위치 설정할 때 플로우: [위치설정버튼 클릭 -> 1. 키워드검색 위치설정화면 -> 지도로 찾기 버튼 클릭 -> 2. 지도로 위치 설정 화면]
'2. 지도로 위치 설정 화면'에서 위치 지정을 했을 경우 popBackStack() 을 두번해서 리포트 화면에 지정한 위치(place)를 전달해줘야했습니다.
그래서 지도에서 위치 설정 버튼을 클릭했을 때, 먼저 popBackStack()을 하여 '1. 키워드검색 위치설정화면'에 savedStateHandle을 사용하여 지정 위치(place)를 전달해주고
바로 또 popBackStack()을 하여 원 화면(리포트화면)에 place를 전달해주는
아주 번거로운 방법을 사용했습니다. 너무 번거롭지만 더 좋은 방법이 떠오르지 않아요..
- 또 걸리는 것이, ViewModel에서 ReportFoodSpot 부분이 너무 긴 것 아닌가 하는 생각이 드네요