### PR TITLE
ROFO-122 위치설정(지도)에서 정확한 위치 반환하도록 수정

### DIFF
--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectPlaceMapScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectPlaceMapScreen.kt
@@ -108,15 +108,21 @@ fun SelectPlaceMapScreen(
                 onClick = vm::onClickCurrentPositionBtn,
             )
 
+            var selectMarkerIconSize by remember { mutableStateOf(IntSize.Zero) }
             PositionSelectMarker(
                 modifier =
                     Modifier
                         .onGloballyPositioned { layoutCoordinates ->
-                            val imageSize = layoutCoordinates.size
-                            val centerX = mapRectSize.width / 2 - imageSize.width / 2
-                            val centerY = mapRectSize.height / 2 - imageSize.height / 2
+                            selectMarkerIconSize = layoutCoordinates.size
+                            val centerX = mapRectSize.width / 2
+                            val centerY = mapRectSize.height / 2
                             vm.onGloballyPositioned(IntOffset(centerX, centerY))
-                        }.offset { state.value.selectMarkerOffset },
+                        }.offset {
+                            IntOffset(
+                                state.value.selectMarkerOffset.x - selectMarkerIconSize.width / 2,
+                                state.value.selectMarkerOffset.y - selectMarkerIconSize.height / 2,
+                            )
+                        },
             )
         }
         PlaceInfoView(

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectPlaceMapScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectPlaceMapScreen.kt
@@ -67,7 +67,6 @@ fun SelectPlaceMapScreen(
                         vm::onMapReady,
                         onCameraMoveStart = vm::onCameraMoveStart,
                         onCameraMoveEnd = vm::onCameraMoveEnd,
-                        selectMarkerOffset = state.value.selectMarkerOffset,
                         position =
                             state.value.initialPosition.run {
                                 LatLng.from(
@@ -217,31 +216,21 @@ private fun mapLifeCycleCallback() =
 private fun kakaoMapReadyCallback(
     onMapReady: (KakaoMap) -> Unit,
     onCameraMoveStart: () -> Unit,
-    onCameraMoveEnd: (LatLng?) -> Unit,
-    selectMarkerOffset: IntOffset,
+    onCameraMoveEnd: () -> Unit,
     position: LatLng,
 ) = object : KakaoMapReadyCallback() {
     override fun onMapReady(map: KakaoMap) {
         onMapReady(map)
-        onCameraMoveEnd(map, onCameraMoveEnd, selectMarkerOffset)
+        onCameraMoveEnd()
         map.setOnCameraMoveStartListener { _, _ ->
             onCameraMoveStart()
         }
         map.setOnCameraMoveEndListener { kakaoMap, _, _ ->
-            onCameraMoveEnd(kakaoMap, onCameraMoveEnd, selectMarkerOffset)
+            onCameraMoveEnd()
         }
     }
 
     override fun getPosition(): LatLng = position
-}
-
-private fun onCameraMoveEnd(
-    map: KakaoMap,
-    onCameraMoveEnd: (LatLng?) -> Unit,
-    selectMarkerOffset: IntOffset,
-) {
-    val position = map.fromScreenPoint(selectMarkerOffset.x, selectMarkerOffset.y)
-    onCameraMoveEnd(position)
 }
 
 @Composable

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectPlaceMapViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/select/place/map/SelectPlaceMapViewModel.kt
@@ -52,8 +52,12 @@ class SelectPlaceMapViewModel @Inject constructor(
         SelectPlaceMapIntent.StartPlaceMap.post()
     }
 
-    fun onCameraMoveEnd(coordinate: LatLng?) {
-        SelectPlaceMapIntent.SearchPlace(coordinate).post()
+    fun onCameraMoveEnd() {
+        val selectedPosition =
+            container.stateFlow.value.run {
+                map?.fromScreenPoint(selectMarkerOffset.x, selectMarkerOffset.y)
+            }
+        SelectPlaceMapIntent.SearchPlace(selectedPosition).post()
     }
 
     fun onClickCurrentPositionBtn(currentPosition: LatLng) {


### PR DESCRIPTION
### 개요
- 위치설정(지도)에서 정확한 위치 반환하도록 수정
### 변경사항
- 위치설정(지도)에서 정확한 위치 반환하도록 수정

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-122) 

### 리뷰어에게 하고 싶은 말
사소한 문제 하나와 큰 문제 하나 때문에 제대로 작동하지 않고 있었습니다.

[사소한 문제]
아이콘 크기를 고려하지 않아서 아이콘의 가운데가 아닌 왼쪽상단 지점을 기준으로 값이 state에 저장되고 있었습니다.

[큰 문제]
selectMarkerOffset 값이 state에 저장되기 이전에 kakaoMapReadyCallback()이 불리기 때문에
화면 좌표를 (0,0)라고 인식한 상태에서 위경도로 변환되고 있었습니다.
(가운데 위치 지정 아이콘 위치가 아닌 왼쪽 상단 0,0 지점을 위경도로 전환하고 있었음)

kakaoMapReadyCallback()이 불려져야지 mapView가 만들어지고 그래야 selectMarkerOffset 값을 알 수 있었기 때문에 
초기화되기 전의 값만 전달 가능했습니다. (Composable이 아니라서 state가 변화해도 업데이트가 안됨)
고민하다가 결국 ViewModel에서 값을 꺼내어 위경도로 전환한 후, Intent에 넘겨주는 방식으로 하게 되었습니다.
-> 이 방법이 mvi스럽지 않다고 생각이 들어서 좀 걸립니다
