### PR TITLE
ROFO-201 장소 검색 화면

### DIFF
--- a/data/src/main/java/com/weit2nd/data/repository/search/SearchHistoryRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/search/SearchHistoryRepositoryImpl.kt
@@ -1,35 +1,30 @@
 package com.weit2nd.data.repository.search
 
 import com.weit2nd.data.source.search.SearchHistoryDataSource
+import com.weit2nd.domain.model.search.SearchHistory
 import com.weit2nd.domain.repository.searchhistory.SearchHistoryRepository
 import javax.inject.Inject
 
 class SearchHistoryRepositoryImpl @Inject constructor(
     private val dataSource: SearchHistoryDataSource,
 ) : SearchHistoryRepository {
-    override suspend fun getSearchHistories(): List<String> {
+    override suspend fun getSearchHistories(): List<SearchHistory> {
         return dataSource.getSearchHistories()
     }
 
-    override suspend fun addSearchHistory(searchWord: String) {
+    override suspend fun addSearchHistory(searchHistory: SearchHistory) {
         val newHistories = dataSource.getSearchHistories().toMutableList()
         // 넣으려는 검색어가 첫번째에 있다면 동작이 불필요하기 때문에 패스
-        val targetIndex = newHistories.indexOf(searchWord).takeIf { it != 0 } ?: return
+        val targetIndex = newHistories.indexOf(searchHistory).takeIf { it != 0 } ?: return
         if (targetIndex != -1) {
-            // 순서가 달라도 같은 요소가 들어있다면 DataStore는 같은 데이터로 인식해 갱신을 안한다.
-            // 그래서 갱신전에 한번 clear를 함
-            // TODO: 6/12/24 (minseong1231) clear 동작을 DataSource로 이동하기
-            // dataSource의 동작을 알기 때문에 이런 동작을 할 수 있는건데 되게 쿨하지 않음
-            // 성능을 챙기면서 로직을 옮길 수 있는 멋진 방법을 생각해보자
-            clearSearchHistory()
             newHistories.removeAt(targetIndex)
         }
-        newHistories.add(0, searchWord)
+        newHistories.add(0, searchHistory)
         dataSource.setSearchHistory(newHistories)
     }
 
-    override suspend fun removeSearchHistory(searchWord: String) {
-        val newHistories = dataSource.getSearchHistories().minus(searchWord)
+    override suspend fun removeSearchHistory(searchHistory: SearchHistory) {
+        val newHistories = dataSource.getSearchHistories().minus(searchHistory)
         dataSource.setSearchHistory(newHistories)
     }
 

--- a/data/src/main/java/com/weit2nd/data/source/search/SearchHistoriesSerializer.kt
+++ b/data/src/main/java/com/weit2nd/data/source/search/SearchHistoriesSerializer.kt
@@ -1,0 +1,26 @@
+package com.weit2nd.data.source.search
+
+import androidx.datastore.core.Serializer
+import com.weit2nd.data.SearchHistoriesPreferences
+import java.io.InputStream
+import java.io.OutputStream
+
+object SearchHistoriesSerializer : Serializer<SearchHistoriesPreferences> {
+    override val defaultValue: SearchHistoriesPreferences
+        get() = SearchHistoriesPreferences.getDefaultInstance()
+
+    override suspend fun readFrom(input: InputStream): SearchHistoriesPreferences {
+        return input.use {
+            SearchHistoriesPreferences.parseFrom(it)
+        }
+    }
+
+    override suspend fun writeTo(
+        t: SearchHistoriesPreferences,
+        output: OutputStream,
+    ) {
+        output.use {
+            t.writeTo(it)
+        }
+    }
+}

--- a/data/src/main/proto/search_history_prefs.proto
+++ b/data/src/main/proto/search_history_prefs.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+option java_package = "com.weit2nd.data";
+option java_multiple_files = true;
+
+message SearchHistoryPreferences {
+  string words = 1;
+  optional double latitude = 2;
+  optional double longitude = 3;
+  bool isPlace = 4;
+}
+
+message SearchHistoriesPreferences {
+  repeated SearchHistoryPreferences histories = 1;
+}

--- a/domain/src/main/java/com/weit2nd/domain/model/search/SearchHistory.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/search/SearchHistory.kt
@@ -1,0 +1,9 @@
+package com.weit2nd.domain.model.search
+
+import com.weit2nd.domain.model.Coordinate
+
+data class SearchHistory(
+    val words: String,
+    val coordinate: Coordinate,
+    val isPlace: Boolean,
+)

--- a/domain/src/main/java/com/weit2nd/domain/repository/searchhistory/SearchHistoryRepository.kt
+++ b/domain/src/main/java/com/weit2nd/domain/repository/searchhistory/SearchHistoryRepository.kt
@@ -1,11 +1,13 @@
 package com.weit2nd.domain.repository.searchhistory
 
+import com.weit2nd.domain.model.search.SearchHistory
+
 interface SearchHistoryRepository {
-    suspend fun getSearchHistories(): List<String>
+    suspend fun getSearchHistories(): List<SearchHistory>
 
-    suspend fun addSearchHistory(searchWord: String)
+    suspend fun addSearchHistory(searchHistory: SearchHistory)
 
-    suspend fun removeSearchHistory(searchWord: String)
+    suspend fun removeSearchHistory(searchHistory: SearchHistory)
 
     suspend fun clearSearchHistory()
 }

--- a/domain/src/main/java/com/weit2nd/domain/usecase/search/AddSearchHistoriesUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/search/AddSearchHistoriesUseCase.kt
@@ -1,5 +1,6 @@
 package com.weit2nd.domain.usecase.search
 
+import com.weit2nd.domain.model.search.SearchHistory
 import com.weit2nd.domain.repository.searchhistory.SearchHistoryRepository
 import javax.inject.Inject
 
@@ -12,7 +13,7 @@ class AddSearchHistoriesUseCase @Inject constructor(
      *
      * 이미 존재하는 기록 이라면 해당 요소의 position을 첫번째로 옮깁니다.
      */
-    suspend operator fun invoke(searchWord: String) {
-        repository.addSearchHistory(searchWord)
+    suspend operator fun invoke(searchHistory: SearchHistory) {
+        repository.addSearchHistory(searchHistory)
     }
 }

--- a/domain/src/main/java/com/weit2nd/domain/usecase/search/GetSearchHistoriesUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/search/GetSearchHistoriesUseCase.kt
@@ -1,5 +1,6 @@
 package com.weit2nd.domain.usecase.search
 
+import com.weit2nd.domain.model.search.SearchHistory
 import com.weit2nd.domain.repository.searchhistory.SearchHistoryRepository
 import javax.inject.Inject
 
@@ -9,7 +10,7 @@ class GetSearchHistoriesUseCase @Inject constructor(
     /**
      * 최근에 추가된 기록 순서로 정렬된 검색 기록 리스트를 가져옵니다.
      */
-    suspend operator fun invoke(): List<String> {
+    suspend operator fun invoke(): List<SearchHistory> {
         return repository.getSearchHistories()
     }
 }

--- a/domain/src/main/java/com/weit2nd/domain/usecase/search/RemoveSearchHistoriesUseCase.kt
+++ b/domain/src/main/java/com/weit2nd/domain/usecase/search/RemoveSearchHistoriesUseCase.kt
@@ -1,5 +1,6 @@
 package com.weit2nd.domain.usecase.search
 
+import com.weit2nd.domain.model.search.SearchHistory
 import com.weit2nd.domain.repository.searchhistory.SearchHistoryRepository
 import javax.inject.Inject
 
@@ -9,7 +10,7 @@ class RemoveSearchHistoriesUseCase @Inject constructor(
     /**
      * 검색 기록을 제거 합니다.
      */
-    suspend operator fun invoke(searchWord: String) {
-        repository.removeSearchHistory(searchWord)
+    suspend operator fun invoke(searchHistory: SearchHistory) {
+        repository.removeSearchHistory(searchHistory)
     }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/model/foodspot/SearchPlaceResult.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/model/foodspot/SearchPlaceResult.kt
@@ -1,0 +1,26 @@
+package com.weit2nd.presentation.model.foodspot
+
+import com.weit2nd.domain.model.Coordinate
+import com.weit2nd.domain.model.search.Place
+import com.weit2nd.presentation.util.getDistanceMeter
+
+data class SearchPlaceResult(
+    val place: Place,
+    val distance: Int,
+)
+
+fun Place.toSearchPlaceResult(currentCoordinate: Coordinate) =
+    SearchPlaceResult(
+        place = this,
+        distance = getDistance(currentCoordinate),
+    )
+
+private fun Place.getDistance(currentCoordinate: Coordinate) =
+    getDistanceMeter(
+        start = currentCoordinate,
+        end =
+            Coordinate(
+                latitude = latitude,
+                longitude = longitude,
+            ),
+    )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/common/SearchTopBar.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/common/SearchTopBar.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -21,10 +22,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import com.weit2nd.presentation.R
+import com.weit2nd.presentation.ui.theme.DarkGray
+import com.weit2nd.presentation.ui.theme.Gray2
+import com.weit2nd.presentation.ui.theme.RoadyFoodyTheme
 
 @Composable
 fun SearchTopBar(
@@ -96,6 +101,10 @@ private fun SearchTextField(
         readOnly = readOnly,
         onValueChange = onSearchWordsChanged,
         interactionSource = interactionSource,
+        textStyle =
+            MaterialTheme.typography.bodyLarge.copy(
+                color = MaterialTheme.colorScheme.onSurface,
+            ),
         keyboardOptions =
             KeyboardOptions.Default.copy(
                 imeAction = ImeAction.Search,
@@ -116,13 +125,9 @@ private fun SearchTextField(
             interactionSource = remember { MutableInteractionSource() },
             placeholder = {
                 Text(
-                    text = "장소를 입력해!",
-                )
-            },
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_search_glass),
-                    contentDescription = "장소 검색 바",
+                    text = stringResource(id = R.string.search_top_bar_hint),
+                    color = Gray2,
+                    style = MaterialTheme.typography.bodyLarge,
                 )
             },
             trailingIcon = {
@@ -138,7 +143,6 @@ private fun SearchTextField(
                     }
                 }
             },
-            // TODO Material Theme를 적용하고 나면 제거
             colors =
                 TextFieldDefaults.colors(
                     disabledContainerColor = Color.White,
@@ -147,7 +151,7 @@ private fun SearchTextField(
                     unfocusedContainerColor = Color.White,
                     unfocusedIndicatorColor = Color.White,
                     disabledIndicatorColor = Color.White,
-                    focusedIndicatorColor = Color(0xFF555555),
+                    focusedIndicatorColor = DarkGray,
                 ),
         )
     }
@@ -156,27 +160,31 @@ private fun SearchTextField(
 @Preview
 @Composable
 private fun SearchTextFieldPreview() {
-    SearchTextField(
-        modifier = Modifier.fillMaxWidth(),
-        searchWords = "안녕하세요",
-        onSearchWordsChanged = {},
-        onClear = {},
-        onSearchButtonClick = {},
-    )
+    RoadyFoodyTheme {
+        SearchTextField(
+            modifier = Modifier.fillMaxWidth(),
+            searchWords = "안녕하세요",
+            onSearchWordsChanged = {},
+            onClear = {},
+            onSearchButtonClick = {},
+        )
+    }
 }
 
 @Preview
 @Composable
 private fun SearchTopBarPerview() {
-    SearchTopBar(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .background(Color.White),
-        searchWords = "감사해요",
-        onClear = {},
-        onSearchButtonClick = {},
-        onSearchWordsChanged = {},
-        onNavigationButtonClick = {},
-    )
+    RoadyFoodyTheme {
+        SearchTopBar(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .background(Color.White),
+            searchWords = "감사해요",
+            onClear = {},
+            onSearchButtonClick = {},
+            onSearchWordsChanged = {},
+            onNavigationButtonClick = {},
+        )
+    }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchIntent.kt
@@ -1,6 +1,7 @@
 package com.weit2nd.presentation.ui.search
 
-import com.weit2nd.domain.model.search.Place
+import com.weit2nd.domain.model.Coordinate
+import com.weit2nd.domain.model.search.SearchHistory
 
 sealed interface SearchIntent {
     data object GetSearchHistory : SearchIntent
@@ -10,7 +11,7 @@ sealed interface SearchIntent {
     ) : SearchIntent
 
     data class RemoveHistory(
-        val history: String,
+        val history: SearchHistory,
     ) : SearchIntent
 
     data class SearchWithWords(
@@ -18,7 +19,8 @@ sealed interface SearchIntent {
     ) : SearchIntent
 
     data class SearchWithPlace(
-        val place: Place,
+        val name: String,
+        val coordinate: Coordinate,
     ) : SearchIntent
 
     data object NavToBack : SearchIntent

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -28,7 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -39,6 +40,10 @@ import com.weit2nd.domain.model.search.SearchHistory
 import com.weit2nd.presentation.R
 import com.weit2nd.presentation.navigation.dto.PlaceSearchDTO
 import com.weit2nd.presentation.ui.common.SearchTopBar
+import com.weit2nd.presentation.ui.theme.Gray1
+import com.weit2nd.presentation.ui.theme.Gray4
+import com.weit2nd.presentation.ui.theme.Gray5
+import com.weit2nd.presentation.ui.theme.RoadyFoodyTheme
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
@@ -71,14 +76,20 @@ fun SearchScreen(
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {
-            SearchTopBar(
-                modifier = Modifier.background(Color.White),
-                searchWords = state.searchWords,
-                onClear = vm::onSearchWordsClear,
-                onSearchButtonClick = vm::onSearchButtonClick,
-                onSearchWordsChanged = vm::onSearchWordsChanged,
-                onNavigationButtonClick = vm::onNavigationButtonClick,
-            )
+            Column {
+                SearchTopBar(
+                    modifier = Modifier.background(MaterialTheme.colorScheme.surface),
+                    searchWords = state.searchWords,
+                    onClear = vm::onSearchWordsClear,
+                    onSearchButtonClick = vm::onSearchButtonClick,
+                    onSearchWordsChanged = vm::onSearchWordsChanged,
+                    onNavigationButtonClick = vm::onNavigationButtonClick,
+                )
+                HorizontalDivider(
+                    modifier = Modifier.fillMaxWidth(),
+                    color = Gray4,
+                )
+            }
         },
     ) {
         SearchContent(
@@ -105,26 +116,26 @@ private fun SearchContent(
         if (state.histories.isNotEmpty()) {
             item {
                 Text(
-                    modifier = Modifier.padding(8.dp),
-                    text = "최근 검색",
-                    color = Color.Black,
-                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(16.dp),
+                    text = stringResource(id = R.string.search_place_history),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    style = MaterialTheme.typography.titleSmall,
                 )
             }
         }
         itemsIndexed(state.histories) { index, history ->
             if (index > 0) {
                 HorizontalDivider(
-                    color = Color.Gray,
+                    color = Gray4,
                     thickness = 1.dp,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
                 )
             }
             SearchHistoryItem(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 8.dp),
+                modifier = Modifier.fillMaxSize(),
                 history = history,
                 onClick = {
                     onHistoryClick(history)
@@ -137,35 +148,28 @@ private fun SearchContent(
         if (state.histories.isNotEmpty() && state.searchResults.isNotEmpty()) {
             item {
                 HorizontalDivider(
-                    color = Color.Gray,
-                    thickness = 4.dp,
+                    color = Gray5,
+                    thickness = 8.dp,
                     modifier = Modifier.fillMaxWidth(),
-                )
-            }
-        }
-        if (state.searchResults.isNotEmpty()) {
-            item {
-                Text(
-                    modifier = Modifier.padding(8.dp),
-                    text = "검색 결과",
-                    color = Color.Black,
-                    fontWeight = FontWeight.Bold,
                 )
             }
         }
         itemsIndexed(state.searchResults) { index, place ->
             if (index > 0) {
                 HorizontalDivider(
-                    color = Color.Gray,
+                    color = Gray4,
                     thickness = 1.dp,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
                 )
             }
             SearchPlaceItem(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(8.dp),
+                        .padding(16.dp),
                 name = place.placeName,
                 address = place.roadAddressName.takeIf { it.isNotEmpty() } ?: place.addressName,
                 onClick = {
@@ -191,7 +195,18 @@ private fun SearchPlaceItem(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Column {
+        Icon(
+            modifier = Modifier.size(32.dp),
+            painter = painterResource(id = R.drawable.ic_search_result_marker),
+            tint = Color.Unspecified,
+            contentDescription = "검색 결과",
+        )
+        Column(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .padding(horizontal = 16.dp),
+        ) {
             Text(
                 text = name,
                 color = Color.Black,
@@ -204,11 +219,6 @@ private fun SearchPlaceItem(
                 fontSize = 12.sp,
             )
         }
-        Icon(
-            modifier = Modifier,
-            painter = painterResource(id = R.drawable.ic_search_glass),
-            contentDescription = "검색 결과",
-        )
     }
 }
 
@@ -223,15 +233,35 @@ private fun SearchHistoryItem(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        val iconRes = if (history.isPlace) {
+            R.drawable.ic_search_history_marker
+        } else {
+            R.drawable.ic_search_glass
+        }
+        val tint = if (history.isPlace) {
+            Color.Unspecified
+        } else {
+            Gray1
+        }
+        Icon(
+            modifier = Modifier
+                .padding(horizontal = 16.dp,)
+                .size(32.dp),
+            painter = painterResource(id = iconRes),
+            tint = tint,
+            contentDescription = "검색 결과",
+        )
         Text(
             modifier =
                 Modifier
+                    .padding(vertical = 16.dp)
                     .weight(1f)
                     .clickable {
                         onClick()
                     },
             text = history.words,
-            fontSize = 18.sp,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
         )
         IconButton(
             modifier = Modifier.size(48.dp),
@@ -239,7 +269,8 @@ private fun SearchHistoryItem(
         ) {
             Icon(
                 modifier = Modifier.padding(0.dp),
-                painter = painterResource(id = android.R.drawable.ic_menu_close_clear_cancel),
+                painter = painterResource(id = R.drawable.ic_input_delete_filled),
+                tint = Color.Unspecified,
                 contentDescription = "제거",
             )
         }
@@ -249,80 +280,84 @@ private fun SearchHistoryItem(
 @Preview
 @Composable
 private fun SearchContentPreview() {
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-    ) {
-        SearchContent(
-            state =
-                SearchState(
-                    histories =
-                        listOf(
-                            SearchHistory(
-                                "안녕하세요",
-                                Coordinate(0.0, 0.0),
-                                true,
+    RoadyFoodyTheme {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            SearchContent(
+                state =
+                    SearchState(
+                        histories =
+                            listOf(
+                                SearchHistory(
+                                    "안녕하세요",
+                                    Coordinate(0.0, 0.0),
+                                    true,
+                                ),
+                                SearchHistory(
+                                    "감사해요",
+                                    Coordinate(0.0, 0.0),
+                                    false,
+                                ),
+                                SearchHistory(
+                                    "잘있어요",
+                                    Coordinate(0.0, 0.0),
+                                    true,
+                                ),
                             ),
-                            SearchHistory(
-                                "감사해요",
-                                Coordinate(0.0, 0.0),
-                                false,
+                        searchResults =
+                            listOf(
+                                Place(
+                                    placeName = "aaa",
+                                    addressName = "aaa",
+                                    roadAddressName = "Aaa",
+                                    longitude = 0.0,
+                                    latitude = 0.0,
+                                    tel = "",
+                                ),
+                                Place(
+                                    placeName = "aaa",
+                                    addressName = "aaa",
+                                    roadAddressName = "Aaa",
+                                    longitude = 0.0,
+                                    latitude = 0.0,
+                                    tel = "",
+                                ),
+                                Place(
+                                    placeName = "aaa",
+                                    addressName = "aaa",
+                                    roadAddressName = "Aaa",
+                                    longitude = 0.0,
+                                    latitude = 0.0,
+                                    tel = "",
+                                ),
                             ),
-                            SearchHistory(
-                                "잘있어요",
-                                Coordinate(0.0, 0.0),
-                                true,
-                            ),
-                        ),
-                    searchResults =
-                        listOf(
-                            Place(
-                                placeName = "aaa",
-                                addressName = "aaa",
-                                roadAddressName = "Aaa",
-                                longitude = 0.0,
-                                latitude = 0.0,
-                                tel = "",
-                            ),
-                            Place(
-                                placeName = "aaa",
-                                addressName = "aaa",
-                                roadAddressName = "Aaa",
-                                longitude = 0.0,
-                                latitude = 0.0,
-                                tel = "",
-                            ),
-                            Place(
-                                placeName = "aaa",
-                                addressName = "aaa",
-                                roadAddressName = "Aaa",
-                                longitude = 0.0,
-                                latitude = 0.0,
-                                tel = "",
-                            ),
-                        ),
-                ),
-            onHistoryRemove = {},
-            onHistoryClick = {},
-            onPlaceClick = {},
-        )
+                    ),
+                onHistoryRemove = {},
+                onHistoryClick = {},
+                onPlaceClick = {},
+            )
+        }
     }
 }
 
 @Preview
 @Composable
 private fun SearchHistoryItemPreview() {
-    SearchHistoryItem(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .background(Color.White),
-        history =
-            SearchHistory(
-                "명륜진사",
-                Coordinate(0.0, 0.0),
-                true,
-            ),
-        onClick = {},
-        onRemove = {},
-    )
+    RoadyFoodyTheme {
+        SearchHistoryItem(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .background(Color.White),
+            history =
+                SearchHistory(
+                    "명륜진사",
+                    Coordinate(0.0, 0.0),
+                    true,
+                ),
+            onClick = {},
+            onRemove = {},
+        )
+    }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchScreen.kt
@@ -33,7 +33,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.weit2nd.domain.model.Coordinate
 import com.weit2nd.domain.model.search.Place
+import com.weit2nd.domain.model.search.SearchHistory
 import com.weit2nd.presentation.R
 import com.weit2nd.presentation.navigation.dto.PlaceSearchDTO
 import com.weit2nd.presentation.ui.common.SearchTopBar
@@ -93,8 +95,8 @@ fun SearchScreen(
 private fun SearchContent(
     modifier: Modifier = Modifier,
     state: SearchState,
-    onHistoryClick: (String) -> Unit,
-    onHistoryRemove: (String) -> Unit,
+    onHistoryClick: (SearchHistory) -> Unit,
+    onHistoryRemove: (SearchHistory) -> Unit,
     onPlaceClick: (Place) -> Unit,
 ) {
     LazyColumn(
@@ -213,7 +215,7 @@ private fun SearchPlaceItem(
 @Composable
 private fun SearchHistoryItem(
     modifier: Modifier = Modifier,
-    history: String,
+    history: SearchHistory,
     onClick: () -> Unit,
     onRemove: () -> Unit,
 ) {
@@ -228,7 +230,7 @@ private fun SearchHistoryItem(
                     .clickable {
                         onClick()
                     },
-            text = history,
+            text = history.words,
             fontSize = 18.sp,
         )
         IconButton(
@@ -253,7 +255,24 @@ private fun SearchContentPreview() {
         SearchContent(
             state =
                 SearchState(
-                    histories = listOf("안녕하세요", "감사해요", "잘있어요"),
+                    histories =
+                        listOf(
+                            SearchHistory(
+                                "안녕하세요",
+                                Coordinate(0.0, 0.0),
+                                true,
+                            ),
+                            SearchHistory(
+                                "감사해요",
+                                Coordinate(0.0, 0.0),
+                                false,
+                            ),
+                            SearchHistory(
+                                "잘있어요",
+                                Coordinate(0.0, 0.0),
+                                true,
+                            ),
+                        ),
                     searchResults =
                         listOf(
                             Place(
@@ -297,7 +316,12 @@ private fun SearchHistoryItemPreview() {
             Modifier
                 .fillMaxWidth()
                 .background(Color.White),
-        history = "명륜진사",
+        history =
+            SearchHistory(
+                "명륜진사",
+                Coordinate(0.0, 0.0),
+                true,
+            ),
         onClick = {},
         onRemove = {},
     )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchScreen.kt
@@ -38,12 +38,15 @@ import com.weit2nd.domain.model.Coordinate
 import com.weit2nd.domain.model.search.Place
 import com.weit2nd.domain.model.search.SearchHistory
 import com.weit2nd.presentation.R
+import com.weit2nd.presentation.model.foodspot.SearchPlaceResult
 import com.weit2nd.presentation.navigation.dto.PlaceSearchDTO
 import com.weit2nd.presentation.ui.common.SearchTopBar
+import com.weit2nd.presentation.ui.theme.DarkGray
 import com.weit2nd.presentation.ui.theme.Gray1
 import com.weit2nd.presentation.ui.theme.Gray4
 import com.weit2nd.presentation.ui.theme.Gray5
 import com.weit2nd.presentation.ui.theme.RoadyFoodyTheme
+import com.weit2nd.presentation.util.getDistanceString
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
@@ -154,7 +157,7 @@ private fun SearchContent(
                 )
             }
         }
-        itemsIndexed(state.searchResults) { index, place ->
+        itemsIndexed(state.searchResults) { index, searchPlaceResult ->
             if (index > 0) {
                 HorizontalDivider(
                     color = Gray4,
@@ -170,10 +173,11 @@ private fun SearchContent(
                     Modifier
                         .fillMaxWidth()
                         .padding(16.dp),
-                name = place.placeName,
-                address = place.roadAddressName.takeIf { it.isNotEmpty() } ?: place.addressName,
+                name = searchPlaceResult.place.placeName,
+                address = searchPlaceResult.place.roadAddressName.takeIf { it.isNotEmpty() } ?: searchPlaceResult.place.addressName,
+                distanceMeter = searchPlaceResult.distance,
                 onClick = {
-                    onPlaceClick(place)
+                    onPlaceClick(searchPlaceResult.place)
                 },
             )
         }
@@ -185,6 +189,7 @@ private fun SearchPlaceItem(
     modifier: Modifier = Modifier,
     name: String,
     address: String,
+    distanceMeter: Int,
     onClick: () -> Unit,
 ) {
     Row(
@@ -219,6 +224,11 @@ private fun SearchPlaceItem(
                 fontSize = 12.sp,
             )
         }
+        Text(
+            text = getDistanceString(LocalContext.current, distanceMeter),
+            style = MaterialTheme.typography.bodyMedium,
+            color = DarkGray,
+        )
     }
 }
 
@@ -233,20 +243,23 @@ private fun SearchHistoryItem(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        val iconRes = if (history.isPlace) {
-            R.drawable.ic_search_history_marker
-        } else {
-            R.drawable.ic_search_glass
-        }
-        val tint = if (history.isPlace) {
-            Color.Unspecified
-        } else {
-            Gray1
-        }
+        val iconRes =
+            if (history.isPlace) {
+                R.drawable.ic_search_history_marker
+            } else {
+                R.drawable.ic_search_glass
+            }
+        val tint =
+            if (history.isPlace) {
+                Color.Unspecified
+            } else {
+                Gray1
+            }
         Icon(
-            modifier = Modifier
-                .padding(horizontal = 16.dp,)
-                .size(32.dp),
+            modifier =
+                Modifier
+                    .padding(horizontal = 16.dp)
+                    .size(32.dp),
             painter = painterResource(id = iconRes),
             tint = tint,
             contentDescription = "검색 결과",
@@ -307,29 +320,38 @@ private fun SearchContentPreview() {
                             ),
                         searchResults =
                             listOf(
-                                Place(
-                                    placeName = "aaa",
-                                    addressName = "aaa",
-                                    roadAddressName = "Aaa",
-                                    longitude = 0.0,
-                                    latitude = 0.0,
-                                    tel = "",
+                                SearchPlaceResult(
+                                    Place(
+                                        placeName = "aaa",
+                                        addressName = "aaa",
+                                        roadAddressName = "Aaa",
+                                        longitude = 0.0,
+                                        latitude = 0.0,
+                                        tel = "",
+                                    ),
+                                    100,
                                 ),
-                                Place(
-                                    placeName = "aaa",
-                                    addressName = "aaa",
-                                    roadAddressName = "Aaa",
-                                    longitude = 0.0,
-                                    latitude = 0.0,
-                                    tel = "",
+                                SearchPlaceResult(
+                                    Place(
+                                        placeName = "aaa",
+                                        addressName = "aaa",
+                                        roadAddressName = "Aaa",
+                                        longitude = 0.0,
+                                        latitude = 0.0,
+                                        tel = "",
+                                    ),
+                                    1234,
                                 ),
-                                Place(
-                                    placeName = "aaa",
-                                    addressName = "aaa",
-                                    roadAddressName = "Aaa",
-                                    longitude = 0.0,
-                                    latitude = 0.0,
-                                    tel = "",
+                                SearchPlaceResult(
+                                    Place(
+                                        placeName = "aaa",
+                                        addressName = "aaa",
+                                        roadAddressName = "Aaa",
+                                        longitude = 0.0,
+                                        latitude = 0.0,
+                                        tel = "",
+                                    ),
+                                    500000,
                                 ),
                             ),
                     ),

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchState.kt
@@ -1,9 +1,10 @@
 package com.weit2nd.presentation.ui.search
 
 import com.weit2nd.domain.model.search.Place
+import com.weit2nd.domain.model.search.SearchHistory
 
 data class SearchState(
     val searchWords: String = "",
     val searchResults: List<Place> = emptyList(),
-    val histories: List<String> = emptyList(),
+    val histories: List<SearchHistory> = emptyList(),
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchState.kt
@@ -1,10 +1,10 @@
 package com.weit2nd.presentation.ui.search
 
-import com.weit2nd.domain.model.search.Place
 import com.weit2nd.domain.model.search.SearchHistory
+import com.weit2nd.presentation.model.foodspot.SearchPlaceResult
 
 data class SearchState(
     val searchWords: String = "",
-    val searchResults: List<Place> = emptyList(),
+    val searchResults: List<SearchPlaceResult> = emptyList(),
     val histories: List<SearchHistory> = emptyList(),
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchViewModel.kt
@@ -10,9 +10,11 @@ import com.weit2nd.domain.usecase.search.GetSearchHistoriesUseCase
 import com.weit2nd.domain.usecase.search.RemoveSearchHistoriesUseCase
 import com.weit2nd.domain.usecase.search.SearchPlacesWithWordUseCase
 import com.weit2nd.presentation.base.BaseViewModel
+import com.weit2nd.presentation.model.foodspot.toSearchPlaceResult
 import com.weit2nd.presentation.navigation.SearchRoutes
 import com.weit2nd.presentation.navigation.dto.CoordinateDTO
 import com.weit2nd.presentation.navigation.dto.PlaceSearchDTO
+import com.weit2nd.presentation.navigation.dto.toCoordinate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import org.orbitmvi.orbit.Container
@@ -112,9 +114,14 @@ class SearchViewModel @Inject constructor(
                             emptyList()
                         }
                     }.onSuccess { places ->
+                        val coordinate = placeSearch.coordinate.toCoordinate()
+                        val searchResults =
+                            places.map {
+                                it.toSearchPlaceResult(coordinate)
+                            }
                         reduce {
                             state.copy(
-                                searchResults = places,
+                                searchResults = searchResults,
                             )
                         }
                     }.onFailure {

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/search/SearchViewModel.kt
@@ -16,6 +16,7 @@ import com.weit2nd.presentation.navigation.dto.CoordinateDTO
 import com.weit2nd.presentation.navigation.dto.PlaceSearchDTO
 import com.weit2nd.presentation.navigation.dto.toCoordinate
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.viewmodel.container
@@ -125,7 +126,9 @@ class SearchViewModel @Inject constructor(
                             )
                         }
                     }.onFailure {
-                        postSideEffect(SearchSideEffect.ShowToastMessage(it.message.toString()))
+                        if (it !is CancellationException) {
+                            postSideEffect(SearchSideEffect.ShowToastMessage(it.message.toString()))
+                        }
                     }
                 }
                 is SearchIntent.RemoveHistory -> {

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/theme/Theme.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/theme/Theme.kt
@@ -1,17 +1,13 @@
 package com.weit2nd.presentation.ui.theme
 
 import android.app.Activity
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
@@ -84,11 +80,6 @@ fun RoadyFoodyTheme(
 ) {
     val colorScheme =
         when {
-            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-                val context = LocalContext.current
-                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-            }
-
             darkTheme -> DarkColorScheme
             else -> LightColorScheme
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/util/GetDistanceMeter.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/util/GetDistanceMeter.kt
@@ -1,0 +1,31 @@
+package com.weit2nd.presentation.util
+
+import com.weit2nd.domain.model.Coordinate
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+private const val EARTH_RADIUS = 6371000.0
+
+/**
+ * 두 좌표 사이의 거리를 미터로 반환 합니다.
+ */
+fun getDistanceMeter(
+    start: Coordinate,
+    end: Coordinate,
+): Int {
+    val latitudeGap = Math.toRadians(start.latitude - end.latitude)
+    val longitudeGap = Math.toRadians(start.longitude - end.longitude)
+
+    val haversineLat = sin(latitudeGap / 2).pow(2)
+    val haversineLng = sin(longitudeGap / 2).pow(2)
+    val haversineFormula =
+        haversineLat +
+            (cos(Math.toRadians(start.latitude)) * cos(Math.toRadians(end.latitude)) * haversineLng)
+
+    val angularDistance = 2 * atan2(sqrt(haversineFormula), sqrt(1 - haversineFormula))
+
+    return (EARTH_RADIUS * angularDistance).toInt() // 거리 (미터)
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/util/GetDistanceMeter.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/util/GetDistanceMeter.kt
@@ -1,6 +1,8 @@
 package com.weit2nd.presentation.util
 
+import android.content.Context
 import com.weit2nd.domain.model.Coordinate
+import com.weit2nd.presentation.R
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.pow
@@ -28,4 +30,21 @@ fun getDistanceMeter(
     val angularDistance = 2 * atan2(sqrt(haversineFormula), sqrt(1 - haversineFormula))
 
     return (EARTH_RADIUS * angularDistance).toInt() // 거리 (미터)
+}
+
+fun getDistanceString(
+    context: Context,
+    distanceMeter: Int,
+): String {
+    return if (distanceMeter >= 1000) {
+        context.getString(
+            R.string.distance_km,
+            distanceMeter / 1000.0,
+        )
+    } else {
+        context.getString(
+            R.string.distance_m,
+            distanceMeter,
+        )
+    }
 }

--- a/presentation/src/main/res/drawable/ic_input_delete_filled.xml
+++ b/presentation/src/main/res/drawable/ic_input_delete_filled.xml
@@ -1,21 +1,12 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="16dp"
-    android:height="17dp"
+    android:height="16dp"
     android:viewportWidth="16"
-    android:viewportHeight="17">
+    android:viewportHeight="16">
   <path
-      android:pathData="M8,8.5m-7,0a7,7 0,1 1,14 0a7,7 0,1 1,-14 0"
-      android:fillColor="#DFDFDF"/>
+      android:pathData="M14.666,8C14.666,11.682 11.682,14.667 8,14.667C4.318,14.667 1.333,11.682 1.333,8C1.333,4.318 4.318,1.333 8,1.333C11.682,1.333 14.666,4.318 14.666,8Z"
+      android:fillColor="#999897"/>
   <path
-      android:strokeWidth="1"
-      android:pathData="M5.5,6L10.5,11"
-      android:fillColor="#00000000"
-      android:strokeColor="#ffffff"
-      android:strokeLineCap="round"/>
-  <path
-      android:strokeWidth="1"
-      android:pathData="M5.5,11L10.5,6"
-      android:fillColor="#00000000"
-      android:strokeColor="#ffffff"
-      android:strokeLineCap="round"/>
+      android:pathData="M5.98,5.98C6.074,5.886 6.201,5.834 6.334,5.834C6.466,5.834 6.593,5.886 6.687,5.98L8,7.293L9.314,5.98C9.359,5.931 9.415,5.891 9.476,5.864C9.537,5.837 9.603,5.822 9.671,5.821C9.738,5.82 9.804,5.832 9.867,5.857C9.929,5.882 9.985,5.92 10.033,5.967C10.08,6.015 10.118,6.071 10.143,6.134C10.168,6.196 10.181,6.262 10.179,6.33C10.178,6.397 10.163,6.463 10.136,6.524C10.109,6.586 10.069,6.641 10.02,6.687L8.707,8L10.02,9.313C10.108,9.408 10.157,9.533 10.154,9.663C10.152,9.792 10.1,9.916 10.008,10.008C9.916,10.099 9.793,10.152 9.663,10.154C9.534,10.156 9.408,10.108 9.314,10.02L8,8.707L6.687,10.02C6.592,10.108 6.467,10.156 6.337,10.154C6.208,10.152 6.084,10.099 5.992,10.008C5.901,9.916 5.848,9.792 5.846,9.663C5.844,9.533 5.892,9.408 5.98,9.313L7.294,8L5.98,6.687C5.887,6.593 5.834,6.466 5.834,6.333C5.834,6.201 5.887,6.074 5.98,5.98Z"
+      android:fillColor="#ffffff"/>
 </vector>

--- a/presentation/src/main/res/drawable/ic_navigate.xml
+++ b/presentation/src/main/res/drawable/ic_navigate.xml
@@ -3,11 +3,11 @@
     android:height="28dp"
     android:viewportWidth="28"
     android:viewportHeight="28">
-  <path
-      android:pathData="M17.5,21L10.5,14L17.5,7"
-      android:strokeLineJoin="round"
-      android:strokeWidth="2"
-      android:fillColor="#00000000"
-      android:strokeColor="#000000"
-      android:strokeLineCap="round"/>
+  <group>
+    <clip-path
+        android:pathData="M0,0h28v28h-28z"/>
+    <path
+        android:pathData="M9.865,13.997L18.867,22.998C19.039,23.17 19.124,23.375 19.121,23.615C19.119,23.854 19.032,24.06 18.86,24.232C18.688,24.404 18.482,24.49 18.243,24.49C18.003,24.49 17.798,24.404 17.626,24.232L8.71,15.323C8.521,15.134 8.384,14.924 8.297,14.692C8.21,14.46 8.167,14.228 8.167,13.997C8.167,13.765 8.21,13.533 8.297,13.301C8.384,13.069 8.521,12.859 8.71,12.671L17.626,3.755C17.798,3.583 18.005,3.498 18.246,3.5C18.488,3.502 18.695,3.589 18.867,3.761C19.039,3.933 19.125,4.139 19.125,4.378C19.125,4.618 19.039,4.823 18.867,4.995L9.865,13.997Z"
+        android:fillColor="#333333"/>
+  </group>
 </vector>

--- a/presentation/src/main/res/drawable/ic_search_glass.xml
+++ b/presentation/src/main/res/drawable/ic_search_glass.xml
@@ -1,18 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="25dp"
-    android:viewportWidth="24"
-    android:viewportHeight="25">
+    android:width="32dp"
+    android:height="35dp"
+    android:viewportWidth="32"
+    android:viewportHeight="35">
   <path
-      android:pathData="M11,11.5m-6,0a6,6 0,1 1,12 0a6,6 0,1 1,-12 0"
-      android:strokeWidth="2"
-      android:fillColor="#00000000"
-      android:strokeColor="#242424"/>
-  <path
-      android:pathData="M16,16.5L19,19.5"
-      android:strokeLineJoin="round"
-      android:strokeWidth="2"
-      android:fillColor="#00000000"
-      android:strokeColor="#242424"
-      android:strokeLineCap="round"/>
+      android:pathData="M21.007,20.668H19.953L19.58,20.288C20.886,18.687 21.673,16.608 21.673,14.346C21.673,9.303 17.793,5.215 13.007,5.215C8.22,5.215 4.34,9.303 4.34,14.346C4.34,19.389 8.22,23.477 13.007,23.477C15.153,23.477 17.126,22.648 18.646,21.272L19.007,21.665V22.775L25.673,29.785L27.66,27.691L21.007,20.668ZM13.007,20.668C9.687,20.668 7.007,17.844 7.007,14.346C7.007,10.848 9.687,8.025 13.007,8.025C16.326,8.025 19.007,10.848 19.007,14.346C19.007,17.844 16.326,20.668 13.007,20.668Z"
+      android:fillColor="#999897"/>
 </vector>

--- a/presentation/src/main/res/drawable/ic_search_history_marker.xml
+++ b/presentation/src/main/res/drawable/ic_search_history_marker.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="35dp"
+    android:viewportWidth="32"
+    android:viewportHeight="35">
+  <path
+      android:pathData="M16,29.44C16,29.44 8,19.607 8,13.286C8,8.636 11.587,4.857 16,4.857C20.413,4.857 24,8.636 24,13.286C24,19.607 16,29.44 16,29.44Z"
+      android:fillColor="#999897"/>
+  <path
+      android:pathData="M16,16.095C17.472,16.095 18.666,14.837 18.666,13.286C18.666,11.734 17.472,10.476 16,10.476C14.527,10.476 13.333,11.734 13.333,13.286C13.333,14.837 14.527,16.095 16,16.095Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/presentation/src/main/res/drawable/ic_search_result_marker.xml
+++ b/presentation/src/main/res/drawable/ic_search_result_marker.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="35dp"
+    android:viewportWidth="32"
+    android:viewportHeight="35">
+  <path
+      android:pathData="M16,29.44C16,29.44 8,19.607 8,13.286C8,8.636 11.587,4.857 16,4.857C20.413,4.857 24,8.636 24,13.286C24,19.607 16,29.44 16,29.44Z"
+      android:fillColor="#5356ff"/>
+  <path
+      android:pathData="M16,16.095C17.472,16.095 18.666,14.837 18.666,13.286C18.666,11.734 17.472,10.476 16,10.476C14.527,10.476 13.333,11.734 13.333,13.286C13.333,14.837 14.527,16.095 16,16.095Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -21,4 +21,7 @@
     <string name="food_spot_detail_closed">영업 종료</string>
     <string name="food_spot_detail_temporarily_closed">이젠 안해..</string>
     <string name="food_spot_detail_operation_hours">%s %s - %s</string>
+
+    <!-- SearchTopBar -->
+    <string name="search_top_bar_hint">지번, 도로명, 건물명으로 검색</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -27,4 +27,7 @@
 
     <!-- SearchPlace -->
     <string name="search_place_history">최근검색</string>
+
+    <string name="distance_km">%.1fkm</string>
+    <string name="distance_m">%dm</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -24,4 +24,7 @@
 
     <!-- SearchTopBar -->
     <string name="search_top_bar_hint">지번, 도로명, 건물명으로 검색</string>
+
+    <!-- SearchPlace -->
+    <string name="search_place_history">최근검색</string>
 </resources>


### PR DESCRIPTION
### 개요
* 장소 검색 화면

### 변경사항
- 장소 검색 화면 디자인 적용
- 검색 기록을 검색어로 검색, 장소를 클릭해서 검색을 분리해서 저장
  - 장소를 클릭 했을 때는 해당 장소의 좌표까지 저장해서 나중에 검색 기록에서 선택 했을 때 그 좌표로 이동 하게끔 만듬
- 두 좌표 사이의 거리를 반환하는 메소드 추가
- 테마의 다이나믹 컬러 제거
  - 우리가 정의한 테마가 안먹히구 있었음

### 관련 지라 및 위키 링크
 - [ROFO-201](https://weit-2nd.atlassian.net/browse/ROFO-201) 

### 프리뷰
![미디어 (25)](https://github.com/user-attachments/assets/63a98a6f-76e6-4612-b6b9-d84c9bc0dfdc)



[ROFO-201]: https://weit-2nd.atlassian.net/browse/ROFO-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ