### PR TITLE
ROFO-216 리뷰 전체 보기 화면

### DIFF
--- a/data/src/main/java/com/weit2nd/data/model/spot/FoodSpotDetailDTO.kt
+++ b/data/src/main/java/com/weit2nd/data/model/spot/FoodSpotDetailDTO.kt
@@ -20,7 +20,7 @@ data class FoodSpotDetailDTO(
     @field:Json(name = "foodSpotsPhotos") val foodSpotsPhotos: List<FoodSpotPhotoDTO>,
     @field:Json(name = "createdDateTime") @StringToLocalDateTime val createdDateTime: LocalDateTime,
     @field:Json(name = "reviewInfo") val reviewInfo: ReviewInfoDTO,
-    @Json(name = "ratingCount") val ratingCounts: List<RatingCountDTO>,
+    @field:Json(name = "ratingCount") val ratingCounts: List<RatingCountDTO>,
 )
 
 @JsonClass(generateAdapter = true)

--- a/data/src/main/java/com/weit2nd/data/model/spot/FoodSpotDetailDTO.kt
+++ b/data/src/main/java/com/weit2nd/data/model/spot/FoodSpotDetailDTO.kt
@@ -19,6 +19,8 @@ data class FoodSpotDetailDTO(
     @field:Json(name = "foodCategoryList") val foodCategoryList: List<FoodCategoryDTO>,
     @field:Json(name = "foodSpotsPhotos") val foodSpotsPhotos: List<FoodSpotPhotoDTO>,
     @field:Json(name = "createdDateTime") @StringToLocalDateTime val createdDateTime: LocalDateTime,
+    @field:Json(name = "reviewInfo") val reviewInfo: ReviewInfoDTO,
+    @Json(name = "ratingCount") val ratingCounts: List<RatingCountDTO>,
 )
 
 @JsonClass(generateAdapter = true)

--- a/data/src/main/java/com/weit2nd/data/model/spot/RatingCountDTO.kt
+++ b/data/src/main/java/com/weit2nd/data/model/spot/RatingCountDTO.kt
@@ -1,0 +1,10 @@
+package com.weit2nd.data.model.spot
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class RatingCountDTO(
+    @field:Json(name = "rating") val rating: Int,
+    @field:Json(name = "count") val count: Int,
+)

--- a/data/src/main/java/com/weit2nd/data/model/spot/ReviewInfoDTO.kt
+++ b/data/src/main/java/com/weit2nd/data/model/spot/ReviewInfoDTO.kt
@@ -1,0 +1,10 @@
+package com.weit2nd.data.model.spot
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ReviewInfoDTO(
+    @Json(name = "avgRating") val average: Float,
+    @field:Json(name = "reviewCount") val reviewCount: Int,
+)

--- a/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/spot/FoodSpotRepositoryImpl.kt
@@ -8,7 +8,9 @@ import com.weit2nd.data.model.spot.FoodSpotPhotoDTO
 import com.weit2nd.data.model.spot.FoodSpotReviewContentDTO
 import com.weit2nd.data.model.spot.FoodSpotReviewUserInfoDTO
 import com.weit2nd.data.model.spot.FoodSpotReviewsDTO
+import com.weit2nd.data.model.spot.RatingCountDTO
 import com.weit2nd.data.model.spot.ReportFoodSpotRequest
+import com.weit2nd.data.model.spot.ReviewInfoDTO
 import com.weit2nd.data.model.spot.UpdateFoodSpotReportRequest
 import com.weit2nd.data.model.spot.toFoodSpotPhoto
 import com.weit2nd.data.model.spot.toRequest
@@ -27,7 +29,9 @@ import com.weit2nd.domain.model.spot.FoodSpotReview
 import com.weit2nd.domain.model.spot.FoodSpotReviewUserInfo
 import com.weit2nd.domain.model.spot.FoodSpotReviews
 import com.weit2nd.domain.model.spot.OperationHour
+import com.weit2nd.domain.model.spot.RatingCount
 import com.weit2nd.domain.model.spot.ReportFoodSpotState
+import com.weit2nd.domain.model.spot.ReviewInfo
 import com.weit2nd.domain.model.spot.ReviewSortType
 import com.weit2nd.domain.repository.spot.FoodSpotRepository
 import okhttp3.internal.http.HTTP_BAD_REQUEST
@@ -303,6 +307,8 @@ class FoodSpotRepositoryImpl @Inject constructor(
             foodCategoryList = foodCategoryList.map { it.toFoodCategory() },
             foodSpotsPhotos = foodSpotsPhotos.map { it.toFoodSpotPhoto() },
             createdDateTime = createdDateTime,
+            reviewInfo = reviewInfo.toReviewInfo(),
+            ratingCounts = ratingCounts.map { it.toRatingCount() },
         )
 
     private fun FoodSpotDetailOperationHoursDTO.toFoodSpotDetailOperationHours() =
@@ -311,6 +317,18 @@ class FoodSpotRepositoryImpl @Inject constructor(
             dayOfWeek = FoodSpotOperationDayOfWeek.findDayOfWeek(dayOfWeek),
             openingHours = toLocalTime(openingHours),
             closingHours = toLocalTime(closingHours),
+        )
+
+    private fun ReviewInfoDTO.toReviewInfo() =
+        ReviewInfo(
+            average = average,
+            reviewCount = reviewCount,
+        )
+
+    private fun RatingCountDTO.toRatingCount() =
+        RatingCount(
+            rating = rating,
+            count = count,
         )
 
     private fun toLocalTime(time: String): LocalTime = LocalTime.parse(time, timeFormatter)

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/FoodSpotDetail.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/FoodSpotDetail.kt
@@ -29,6 +29,8 @@ data class FoodSpotDetail(
     val foodCategoryList: List<FoodCategory>,
     val foodSpotsPhotos: List<FoodSpotPhoto>,
     val createdDateTime: LocalDateTime,
+    val reviewInfo: ReviewInfo,
+    val ratingCounts: List<RatingCount>,
 )
 
 data class FoodSpotDetailOperationHours(

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/RatingCount.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/RatingCount.kt
@@ -1,0 +1,6 @@
+package com.weit2nd.domain.model.spot
+
+data class RatingCount(
+    val rating: Int,
+    val count: Int,
+)

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/ReviewInfo.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/ReviewInfo.kt
@@ -1,0 +1,6 @@
+package com.weit2nd.domain.model.spot
+
+data class ReviewInfo(
+    val average: Float,
+    val reviewCount: Int,
+)

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -345,7 +345,7 @@ private fun NavGraphBuilder.searchComposable(navController: NavHostController) {
 
 private fun NavGraphBuilder.reviewHistoryComposable(navController: NavHostController) {
     composable(
-        route = "${ReviewHistoryRoutes.GRAPT}/{${ReviewHistoryRoutes.REVIEW_HISTORY_KEY}}",
+        route = "${ReviewHistoryRoutes.GRAPH}/{${ReviewHistoryRoutes.REVIEW_HISTORY_KEY}}",
         arguments =
             listOf(
                 navArgument(ReviewHistoryRoutes.REVIEW_HISTORY_KEY) {
@@ -460,7 +460,7 @@ private fun NavHostController.navigateToReviewHistory(
     builder: NavOptionsBuilder.() -> Unit = {},
 ) {
     val reviewHistoryJson = Uri.encode(Gson().toJson(reviewHistoryDTO))
-    navigate("${ReviewHistoryRoutes.GRAPT}/$reviewHistoryJson", builder)
+    navigate("${ReviewHistoryRoutes.GRAPH}/$reviewHistoryJson", builder)
 }
 
 object SplashRoutes {
@@ -534,6 +534,6 @@ object FoodSpotDetailRoutes {
 }
 
 object ReviewHistoryRoutes {
-    const val GRAPT = "review_history"
+    const val GRAPH = "review_history"
     const val REVIEW_HISTORY_KEY = "review_history_key"
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -16,6 +16,7 @@ import androidx.navigation.navArgument
 import com.google.gson.Gson
 import com.weit2nd.domain.model.Coordinate
 import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
+import com.weit2nd.presentation.navigation.dto.FoodSpotReviewDTO
 import com.weit2nd.presentation.navigation.dto.PlaceSearchDTO
 import com.weit2nd.presentation.navigation.dto.ReviewHistoryDTO
 import com.weit2nd.presentation.navigation.dto.toCoordinateDTO
@@ -24,6 +25,7 @@ import com.weit2nd.presentation.navigation.dto.toPlaceDTO
 import com.weit2nd.presentation.navigation.dto.toTermIdsDTO
 import com.weit2nd.presentation.navigation.type.CoordinateType
 import com.weit2nd.presentation.navigation.type.FoodSpotForReviewType
+import com.weit2nd.presentation.navigation.type.FoodSpotReviewType
 import com.weit2nd.presentation.navigation.type.ImageViewerDataType
 import com.weit2nd.presentation.navigation.type.PlaceSearchType
 import com.weit2nd.presentation.navigation.type.ReviewHistoryType
@@ -32,6 +34,7 @@ import com.weit2nd.presentation.ui.common.imageviewer.ImageViewerData
 import com.weit2nd.presentation.ui.common.imageviewer.ImageViewerScreen
 import com.weit2nd.presentation.ui.foodspot.detail.FoodSpotDetailScreen
 import com.weit2nd.presentation.ui.foodspot.report.FoodSpotReportScreen
+import com.weit2nd.presentation.ui.foodspot.review.FoodSpotReviewScreen
 import com.weit2nd.presentation.ui.home.HomeScreen
 import com.weit2nd.presentation.ui.login.LoginScreen
 import com.weit2nd.presentation.ui.mypage.MyPageScreen
@@ -74,6 +77,7 @@ fun AppNavHost(
         searchComposable(navController)
         foodSpotDetailComposable(navController)
         reviewHistoryComposable(navController)
+        foodSpotReviewComposable(navController)
     }
 }
 
@@ -378,6 +382,27 @@ private fun NavGraphBuilder.foodSpotDetailComposable(navController: NavHostContr
             navToPostReview = {
                 navController.navigateToPostReview(it)
             },
+            navToFoodSpotReview = {
+                navController.navigateToFoodSpotReview(it)
+            },
+        )
+    }
+}
+
+private fun NavGraphBuilder.foodSpotReviewComposable(navController: NavHostController) {
+    composable(
+        route = "${FoodSpotReviewRoutes.GRAPH}/{${FoodSpotReviewRoutes.FOOD_SPOT_REVIEW_KEY}}",
+        arguments =
+            listOf(
+                navArgument(FoodSpotReviewRoutes.FOOD_SPOT_REVIEW_KEY) {
+                    type = FoodSpotReviewType()
+                },
+            ),
+    ) {
+        FoodSpotReviewScreen(
+            navToPostReview = {
+                navController.navigateToPostReview(it)
+            },
         )
     }
 }
@@ -463,6 +488,14 @@ private fun NavHostController.navigateToReviewHistory(
     navigate("${ReviewHistoryRoutes.GRAPH}/$reviewHistoryJson", builder)
 }
 
+private fun NavHostController.navigateToFoodSpotReview(
+    foodSpotReviewDTO: FoodSpotReviewDTO,
+    builder: NavOptionsBuilder.() -> Unit = {},
+) {
+    val foodSpotReviewJson = Uri.encode(Gson().toJson(foodSpotReviewDTO))
+    navigate("${FoodSpotReviewRoutes.GRAPH}/$foodSpotReviewJson", builder)
+}
+
 object SplashRoutes {
     const val GRAPH = "splash"
 }
@@ -536,4 +569,9 @@ object FoodSpotDetailRoutes {
 object ReviewHistoryRoutes {
     const val GRAPH = "review_history"
     const val REVIEW_HISTORY_KEY = "review_history_key"
+}
+
+object FoodSpotReviewRoutes {
+    const val GRAPH = "food_spot_review"
+    const val FOOD_SPOT_REVIEW_KEY = "food_spot_review_key"
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/FoodCategoryDTO.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/FoodCategoryDTO.kt
@@ -15,3 +15,9 @@ fun FoodCategoryDTO.toFoodCategory() =
         id = id,
         name = name,
     )
+
+fun FoodCategory.toFoodCategoryDTO() =
+    FoodCategoryDTO(
+        id = id,
+        name = name,
+    )

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/FoodCategoryDTO.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/FoodCategoryDTO.kt
@@ -1,0 +1,17 @@
+package com.weit2nd.presentation.navigation.dto
+
+import android.os.Parcelable
+import com.weit2nd.domain.model.spot.FoodCategory
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class FoodCategoryDTO(
+    val id: Long,
+    val name: String,
+) : Parcelable
+
+fun FoodCategoryDTO.toFoodCategory() =
+    FoodCategory(
+        id = id,
+        name = name,
+    )

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/FoodSpotReviewDTO.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/FoodSpotReviewDTO.kt
@@ -1,0 +1,16 @@
+package com.weit2nd.presentation.navigation.dto
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class FoodSpotReviewDTO(
+    val id: Long = 0,
+    val name: String = "",
+    val foodSpotsPhotos: List<String> = emptyList(),
+    val movableFoodSpots: Boolean,
+    val categories: List<FoodCategoryDTO>,
+    val reviewCount: Int,
+    val averageRating: Float,
+    val ratingCounts: List<RatingCountDTO>,
+) : Parcelable

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/RatingCountDTO.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/RatingCountDTO.kt
@@ -1,0 +1,17 @@
+package com.weit2nd.presentation.navigation.dto
+
+import android.os.Parcelable
+import com.weit2nd.domain.model.spot.RatingCount
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class RatingCountDTO(
+    val rating: Int,
+    val count: Int,
+) : Parcelable
+
+fun RatingCountDTO.toRatingCount() =
+    RatingCount(
+        rating = rating,
+        count = count,
+    )

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/RatingCountDTO.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/dto/RatingCountDTO.kt
@@ -15,3 +15,9 @@ fun RatingCountDTO.toRatingCount() =
         rating = rating,
         count = count,
     )
+
+fun RatingCount.toRatingCountDTO() =
+    RatingCountDTO(
+        rating = rating,
+        count = count,
+    )

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/type/FoodSpotReviewType.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/type/FoodSpotReviewType.kt
@@ -1,0 +1,9 @@
+package com.weit2nd.presentation.navigation.type
+
+import com.weit2nd.presentation.navigation.dto.FoodSpotReviewDTO
+
+class FoodSpotReviewType :
+    BaseNavType<FoodSpotReviewDTO>(
+        target = FoodSpotReviewDTO::class.java,
+        isNullableAllowed = false,
+    )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/common/FoodSpotImagePager.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/common/FoodSpotImagePager.kt
@@ -1,0 +1,43 @@
+package com.weit2nd.presentation.ui.common
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import coil.compose.AsyncImage
+import com.weit2nd.presentation.R
+import com.weit2nd.presentation.ui.theme.Gray4
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun FoodSpotImagePager(
+    modifier: Modifier = Modifier,
+    pagerState: PagerState,
+    images: List<String>,
+    onImageClick: (Int) -> Unit,
+) {
+    HorizontalPager(
+        modifier = modifier,
+        state = pagerState,
+    ) { page ->
+        AsyncImage(
+            modifier =
+            Modifier
+                .fillMaxSize()
+                .clickable {
+                    onImageClick(page)
+                },
+            model = images[page],
+            contentDescription = "foodSpotImage$page",
+            contentScale = ContentScale.Crop,
+            fallback = painterResource(id = R.drawable.ic_input_delete_filled),
+            placeholder = ColorPainter(Gray4),
+        )
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/common/ReviewRequest.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/common/ReviewRequest.kt
@@ -1,0 +1,37 @@
+package com.weit2nd.presentation.ui.common
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.weit2nd.presentation.R
+
+@Composable
+fun ReviewRequest(
+    modifier: Modifier = Modifier,
+    onPostReviewClick: () -> Unit,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(id = R.string.food_spot_detail_post_review_description),
+            color = MaterialTheme.colorScheme.onSurface,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        BorderButton(
+            text = stringResource(id = R.string.food_spot_detail_post_review_button),
+            onClick = onPostReviewClick,
+        )
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/common/ReviewTotal.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/common/ReviewTotal.kt
@@ -1,0 +1,66 @@
+package com.weit2nd.presentation.ui.common
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.weit2nd.presentation.R
+import com.weit2nd.presentation.ui.theme.Gray2
+
+@Composable
+fun ReviewTotal(
+    modifier: Modifier = Modifier,
+    averageRating: Float,
+    reviewCount: Int,
+    onClick: (() -> Unit)? = null,
+    isReadMoreVisible: Boolean,
+) {
+    Row(
+        modifier =
+            modifier.clickable {
+                onClick?.invoke()
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            modifier = Modifier.size(20.dp),
+            painter = painterResource(id = R.drawable.ic_star),
+            contentDescription = "review rating",
+            tint = MaterialTheme.colorScheme.tertiary,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = averageRating.toString(),
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.tertiary,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text =
+                stringResource(
+                    id = R.string.food_spot_detail_review_count,
+                    reviewCount,
+                ),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        if (isReadMoreVisible) {
+            Icon(
+                modifier = Modifier.size(20.dp),
+                painter = painterResource(id = R.drawable.ic_arrow_right),
+                contentDescription = "navigate to review detail",
+                tint = Gray2,
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/common/TitleAndCategory.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/common/TitleAndCategory.kt
@@ -1,0 +1,63 @@
+package com.weit2nd.presentation.ui.common
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.weit2nd.domain.model.spot.FoodCategory
+import com.weit2nd.presentation.R
+import com.weit2nd.presentation.ui.theme.Gray1
+
+@Composable
+fun TitleAndCategory(
+    modifier: Modifier = Modifier,
+    title: String,
+    isFoodTruck: Boolean,
+    categories: List<FoodCategory>,
+) {
+    val categoriseText =
+        categories.joinToString(", ") {
+            it.name
+        }
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Bold,
+        )
+        if (isFoodTruck) {
+            Spacer(modifier = Modifier.width(4.dp))
+            Icon(
+                modifier = Modifier.size(16.dp),
+                painter = painterResource(id = R.drawable.ic_truck),
+                contentDescription = "food truck",
+                tint = MaterialTheme.colorScheme.secondary,
+            )
+        }
+        if (categories.isNotEmpty()) {
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                modifier = Modifier.weight(1f),
+                text = categoriseText,
+                style = MaterialTheme.typography.labelLarge,
+                color = Gray1,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailIntent.kt
@@ -23,4 +23,6 @@ sealed interface FoodSpotDetailIntent {
         val position: Int,
         val expandState: Boolean,
     ) : FoodSpotDetailIntent
+
+    data object NavToFoodSpotReview : FoodSpotDetailIntent
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -68,6 +67,7 @@ import com.weit2nd.presentation.model.foodspot.OperationHour
 import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
 import com.weit2nd.presentation.ui.common.BorderButton
 import com.weit2nd.presentation.ui.common.ReviewItem
+import com.weit2nd.presentation.ui.common.ReviewRequest
 import com.weit2nd.presentation.ui.theme.Gray1
 import com.weit2nd.presentation.ui.theme.Gray2
 import com.weit2nd.presentation.ui.theme.Gray4
@@ -453,29 +453,6 @@ private fun ReviewTotal(
             painter = painterResource(id = R.drawable.ic_arrow_right),
             contentDescription = "navigate to review detail",
             tint = Gray2,
-        )
-    }
-}
-
-@Composable
-private fun ReviewRequest(
-    modifier: Modifier = Modifier,
-    onPostReviewClick: () -> Unit,
-) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            text = stringResource(id = R.string.food_spot_detail_post_review_description),
-            color = MaterialTheme.colorScheme.onSurface,
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        BorderButton(
-            text = stringResource(id = R.string.food_spot_detail_post_review_button),
-            onClick = onPostReviewClick,
         )
     }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
@@ -63,6 +63,7 @@ import com.weit2nd.presentation.ui.common.BorderButton
 import com.weit2nd.presentation.ui.common.FoodSpotImagePager
 import com.weit2nd.presentation.ui.common.ReviewItem
 import com.weit2nd.presentation.ui.common.ReviewRequest
+import com.weit2nd.presentation.ui.common.ReviewTotal
 import com.weit2nd.presentation.ui.common.TitleAndCategory
 import com.weit2nd.presentation.ui.theme.Gray2
 import com.weit2nd.presentation.ui.theme.Gray4
@@ -284,6 +285,7 @@ private fun FoodSpotDetailContent(
                     onClick = {
                         // TODO 리뷰 더보기 이동
                     },
+                    isReadMoreVisible = true,
                 )
                 Spacer(modifier = Modifier.height(16.dp))
             }
@@ -332,51 +334,6 @@ private fun FoodSpotDetailContent(
                 Spacer(modifier = Modifier.height(8.dp))
             }
         }
-    }
-}
-
-@Composable
-private fun ReviewTotal(
-    modifier: Modifier = Modifier,
-    averageRating: Float,
-    reviewCount: Int,
-    onClick: () -> Unit,
-) {
-    Row(
-        modifier =
-            modifier.clickable {
-                onClick()
-            },
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Icon(
-            modifier = Modifier.size(20.dp),
-            painter = painterResource(id = R.drawable.ic_star),
-            contentDescription = "review rating",
-            tint = MaterialTheme.colorScheme.tertiary,
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = averageRating.toString(),
-            style = MaterialTheme.typography.titleLarge,
-            color = MaterialTheme.colorScheme.tertiary,
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text =
-                stringResource(
-                    id = R.string.food_spot_detail_review_count,
-                    reviewCount,
-                ),
-            style = MaterialTheme.typography.titleSmall,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        Icon(
-            modifier = Modifier.size(20.dp),
-            painter = painterResource(id = R.drawable.ic_arrow_right),
-            contentDescription = "navigate to review detail",
-            tint = Gray2,
-        )
     }
 }
 

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
@@ -59,6 +59,7 @@ import com.weit2nd.domain.model.spot.FoodSpotOpenState
 import com.weit2nd.presentation.R
 import com.weit2nd.presentation.model.foodspot.OperationHour
 import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
+import com.weit2nd.presentation.navigation.dto.FoodSpotReviewDTO
 import com.weit2nd.presentation.ui.common.BorderButton
 import com.weit2nd.presentation.ui.common.FoodSpotImagePager
 import com.weit2nd.presentation.ui.common.ReviewItem
@@ -80,6 +81,7 @@ fun FoodSpotDetailScreen(
     vm: FoodSpotDetailViewModel = hiltViewModel(),
     navToBack: () -> Unit,
     navToPostReview: (FoodSpotForReviewDTO) -> Unit,
+    navToFoodSpotReview: (FoodSpotReviewDTO) -> Unit,
 ) {
     val state by vm.collectAsState()
 
@@ -108,6 +110,10 @@ fun FoodSpotDetailScreen(
 
             is FoodSpotDetailSideEffect.NavToPostReview -> {
                 navToPostReview(sideEffect.foodSpotForReviewDTO)
+            }
+
+            is FoodSpotDetailSideEffect.NavToFoodSpotReview -> {
+                navToFoodSpotReview(sideEffect.foodSpotReviewDTO)
             }
         }
     }
@@ -154,6 +160,7 @@ fun FoodSpotDetailScreen(
         onPostReviewClick = vm::onPostReviewClick,
         onReviewContentClick = vm::onReviewContentsClick,
         onReviewContentReadMoreClick = vm::onReviewContentsReadMoreClick,
+        onReviewReadMoreClick = vm::onReviewReadMoreClick,
     )
 }
 
@@ -170,6 +177,7 @@ private fun FoodSpotDetailContent(
     onPostReviewClick: () -> Unit,
     onReviewContentClick: (position: Int) -> Unit,
     onReviewContentReadMoreClick: (position: Int) -> Unit,
+    onReviewReadMoreClick: () -> Unit,
 ) {
     val imagePagerState =
         rememberPagerState(
@@ -282,9 +290,7 @@ private fun FoodSpotDetailContent(
                         ),
                     averageRating = state.averageRating,
                     reviewCount = state.reviewCount,
-                    onClick = {
-                        // TODO 리뷰 더보기 이동
-                    },
+                    onClick = onReviewReadMoreClick,
                     isReadMoreVisible = true,
                 )
                 Spacer(modifier = Modifier.height(16.dp))
@@ -326,9 +332,7 @@ private fun FoodSpotDetailContent(
                 ) {
                     BorderButton(
                         text = stringResource(id = R.string.food_spot_detail_view_more_review),
-                        onClick = {
-                            // TODO 리뷰 더보기 화면으로 이동
-                        },
+                        onClick = onReviewReadMoreClick,
                     )
                 }
                 Spacer(modifier = Modifier.height(8.dp))
@@ -523,6 +527,7 @@ private fun FoodSpotDetailPreview() {
                 onPostReviewClick = {},
                 onReviewContentClick = {},
                 onReviewContentReadMoreClick = {},
+                onReviewReadMoreClick = {},
             )
         }
     }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
@@ -19,8 +19,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
@@ -37,8 +35,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.ColorPainter
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -47,7 +43,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.AsyncImage
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.KakaoMapReadyCallback
 import com.kakao.vectormap.LatLng
@@ -65,6 +60,7 @@ import com.weit2nd.presentation.R
 import com.weit2nd.presentation.model.foodspot.OperationHour
 import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
 import com.weit2nd.presentation.ui.common.BorderButton
+import com.weit2nd.presentation.ui.common.FoodSpotImagePager
 import com.weit2nd.presentation.ui.common.ReviewItem
 import com.weit2nd.presentation.ui.common.ReviewRequest
 import com.weit2nd.presentation.ui.common.TitleAndCategory
@@ -336,34 +332,6 @@ private fun FoodSpotDetailContent(
                 Spacer(modifier = Modifier.height(8.dp))
             }
         }
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun FoodSpotImagePager(
-    modifier: Modifier = Modifier,
-    pagerState: PagerState,
-    images: List<String>,
-    onImageClick: (Int) -> Unit,
-) {
-    HorizontalPager(
-        modifier = modifier,
-        state = pagerState,
-    ) { page ->
-        AsyncImage(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .clickable {
-                        onImageClick(page)
-                    },
-            model = images[page],
-            contentDescription = "foodSpotImage$page",
-            contentScale = ContentScale.Crop,
-            fallback = painterResource(id = R.drawable.ic_input_delete_filled),
-            placeholder = ColorPainter(Gray4),
-        )
     }
 }
 

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -68,7 +67,7 @@ import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
 import com.weit2nd.presentation.ui.common.BorderButton
 import com.weit2nd.presentation.ui.common.ReviewItem
 import com.weit2nd.presentation.ui.common.ReviewRequest
-import com.weit2nd.presentation.ui.theme.Gray1
+import com.weit2nd.presentation.ui.common.TitleAndCategory
 import com.weit2nd.presentation.ui.theme.Gray2
 import com.weit2nd.presentation.ui.theme.Gray4
 import com.weit2nd.presentation.ui.theme.Gray5
@@ -365,50 +364,6 @@ private fun FoodSpotImagePager(
             fallback = painterResource(id = R.drawable.ic_input_delete_filled),
             placeholder = ColorPainter(Gray4),
         )
-    }
-}
-
-@Composable
-private fun TitleAndCategory(
-    modifier: Modifier = Modifier,
-    title: String,
-    isFoodTruck: Boolean,
-    categories: List<FoodCategory>,
-) {
-    val categoriseText =
-        categories.joinToString(", ") {
-            it.name
-        }
-    Row(
-        modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleLarge,
-            color = MaterialTheme.colorScheme.onSurface,
-            fontWeight = FontWeight.Bold,
-        )
-        if (isFoodTruck) {
-            Spacer(modifier = Modifier.width(4.dp))
-            Icon(
-                modifier = Modifier.size(16.dp),
-                painter = painterResource(id = R.drawable.ic_truck),
-                contentDescription = "food truck",
-                tint = MaterialTheme.colorScheme.secondary,
-            )
-        }
-        if (categories.isNotEmpty()) {
-            Spacer(modifier = Modifier.width(4.dp))
-            Text(
-                modifier = Modifier.weight(1f),
-                text = categoriseText,
-                style = MaterialTheme.typography.labelLarge,
-                color = Gray1,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
     }
 }
 

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailSideEffect.kt
@@ -3,6 +3,7 @@ package com.weit2nd.presentation.ui.foodspot.detail
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.LatLng
 import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
+import com.weit2nd.presentation.navigation.dto.FoodSpotReviewDTO
 
 sealed interface FoodSpotDetailSideEffect {
     data object NavToBack : FoodSpotDetailSideEffect
@@ -14,5 +15,9 @@ sealed interface FoodSpotDetailSideEffect {
 
     data class NavToPostReview(
         val foodSpotForReviewDTO: FoodSpotForReviewDTO,
+    ) : FoodSpotDetailSideEffect
+
+    data class NavToFoodSpotReview(
+        val foodSpotReviewDTO: FoodSpotReviewDTO,
     ) : FoodSpotDetailSideEffect
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailState.kt
@@ -4,11 +4,11 @@ import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.LatLng
 import com.weit2nd.domain.model.spot.FoodCategory
 import com.weit2nd.domain.model.spot.FoodSpotOpenState
+import com.weit2nd.domain.model.spot.RatingCount
 import com.weit2nd.presentation.model.foodspot.OperationHour
 import com.weit2nd.presentation.model.reivew.ExpendableReview
 import java.time.LocalTime
 
-// TODO 리뷰 카운트랑 평균 별점 가져와야됨
 data class FoodSpotDetailState(
     val name: String = "",
     val position: LatLng = LatLng.from(37.5597706, 126.9423666),
@@ -22,6 +22,7 @@ data class FoodSpotDetailState(
     val foodSpotsPhotos: List<String> = emptyList(),
     val reviews: List<ExpendableReview> = emptyList(),
     val reviewCount: Int = 256,
+    val ratingCounts: List<RatingCount> = emptyList(),
     val averageRating: Float = 4.8f,
     val hasMoreReviews: Boolean = false,
     val isOperationHoursOpen: Boolean = false,

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailViewModel.kt
@@ -16,6 +16,9 @@ import com.weit2nd.presentation.model.foodspot.Review
 import com.weit2nd.presentation.model.reivew.ExpendableReview
 import com.weit2nd.presentation.navigation.FoodSpotDetailRoutes
 import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
+import com.weit2nd.presentation.navigation.dto.FoodSpotReviewDTO
+import com.weit2nd.presentation.navigation.dto.toFoodCategoryDTO
+import com.weit2nd.presentation.navigation.dto.toRatingCountDTO
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.viewmodel.container
@@ -79,6 +82,10 @@ class FoodSpotDetailViewModel @Inject constructor(
                 position = position,
                 expandState = true,
             ).post()
+    }
+
+    fun onReviewReadMoreClick() {
+        FoodSpotDetailIntent.NavToFoodSpotReview.post()
     }
 
     private fun FoodSpotDetailIntent.post() =
@@ -212,6 +219,22 @@ class FoodSpotDetailViewModel @Inject constructor(
                             reviews = updatedReviews,
                         )
                     }
+                }
+
+                FoodSpotDetailIntent.NavToFoodSpotReview -> {
+                    val id = foodSpotId ?: return@intent
+                    val foodSpotReviewDTO =
+                        FoodSpotReviewDTO(
+                            id = id,
+                            name = state.name,
+                            foodSpotsPhotos = state.foodSpotsPhotos,
+                            movableFoodSpots = state.movableFoodSpots,
+                            categories = state.foodCategoryList.map { it.toFoodCategoryDTO() },
+                            reviewCount = state.reviewCount,
+                            averageRating = state.averageRating,
+                            ratingCounts = state.ratingCounts.map { it.toRatingCountDTO() },
+                        )
+                    postSideEffect(FoodSpotDetailSideEffect.NavToFoodSpotReview(foodSpotReviewDTO))
                 }
             }
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailViewModel.kt
@@ -126,6 +126,9 @@ class FoodSpotDetailViewModel @Inject constructor(
                                 todayCloseTime = getTodayCloseTime(detail.operationHoursList),
                                 foodCategoryList = detail.foodCategoryList,
                                 foodSpotsPhotos = detail.foodSpotsPhotos.map { it.image },
+                                reviewCount = detail.reviewInfo.reviewCount,
+                                averageRating = detail.reviewInfo.average,
+                                ratingCounts = detail.ratingCounts,
                                 reviews = foodSpotReviews.reviews.map { it.toReview() },
                                 hasMoreReviews = foodSpotReviews.hasNext,
                             )

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewIntent.kt
@@ -1,0 +1,14 @@
+package com.weit2nd.presentation.ui.foodspot.review
+
+sealed interface FoodSpotReviewIntent {
+    data object NavToPostReview : FoodSpotReviewIntent
+
+    data class LoadNextReviews(
+        val lastId: Long?,
+    ) : FoodSpotReviewIntent
+
+    data class ChangeReviewContentExpendState(
+        val position: Int,
+        val expandState: Boolean,
+    ) : FoodSpotReviewIntent
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewScreen.kt
@@ -1,0 +1,290 @@
+package com.weit2nd.presentation.ui.foodspot.review
+
+import android.widget.Toast
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.weit2nd.domain.model.spot.RatingCount
+import com.weit2nd.presentation.R
+import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
+import com.weit2nd.presentation.ui.common.FoodSpotImagePager
+import com.weit2nd.presentation.ui.common.ReviewItem
+import com.weit2nd.presentation.ui.common.ReviewRequest
+import com.weit2nd.presentation.ui.common.ReviewTotal
+import com.weit2nd.presentation.ui.common.TitleAndCategory
+import com.weit2nd.presentation.ui.theme.Gray4
+import com.weit2nd.presentation.ui.theme.Gray5
+import com.weit2nd.presentation.ui.theme.RoadyFoodyTheme
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun FoodSpotReviewScreen(
+    vm: FoodSpotReviewViewModel = hiltViewModel(),
+    navToPostReview: (FoodSpotForReviewDTO) -> Unit,
+) {
+    val state by vm.collectAsState()
+    val imagePagerState =
+        rememberPagerState(
+            pageCount = { state.foodSpotsPhotos.size },
+        )
+    val lazyListState = rememberLazyListState()
+    val context = LocalContext.current
+    vm.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is FoodSpotReviewSideEffect.NavToPostReview -> {
+                navToPostReview(sideEffect.foodSpotForReviewDTO)
+            }
+            FoodSpotReviewSideEffect.ShowNetworkErrorMessage -> {
+                Toast
+                    .makeText(
+                        context,
+                        context.getString(R.string.error_network),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+            }
+        }
+    }
+    val lastVisibleItemIndex by
+        remember {
+            derivedStateOf {
+                lazyListState.layoutInfo.visibleItemsInfo
+                    .lastOrNull()
+                    ?.index ?: 0
+            }
+        }
+    val lazyListSize by
+        remember {
+            derivedStateOf {
+                lazyListState.layoutInfo.totalItemsCount
+            }
+        }
+
+    LaunchedEffect(Unit) {
+        vm.onCreate()
+    }
+
+    LaunchedEffect(lastVisibleItemIndex) {
+        vm.onLastVisibleItemChanged(
+            totalSize = lazyListSize,
+            currentPosition = lastVisibleItemIndex,
+        )
+    }
+
+    FoodSpotReviewContent(
+        modifier = Modifier.fillMaxSize(),
+        foodSpotReviewState = state,
+        imagePagerState = imagePagerState,
+        lazyListState = lazyListState,
+        onImageClick = vm::onImageClick,
+        onPostReviewClick = vm::onPostReviewClick,
+        onReviewContentReadMoreClick = vm::onReviewContentsReadMoreClick,
+        onReviewContentClick = vm::onReviewContentsClick,
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun FoodSpotReviewContent(
+    modifier: Modifier = Modifier,
+    foodSpotReviewState: FoodSpotReviewState,
+    imagePagerState: PagerState,
+    lazyListState: LazyListState,
+    onImageClick: (position: Int) -> Unit,
+    onPostReviewClick: () -> Unit,
+    onReviewContentClick: (position: Int) -> Unit,
+    onReviewContentReadMoreClick: (position: Int) -> Unit,
+) {
+    LazyColumn(
+        modifier = modifier,
+        state = lazyListState,
+    ) {
+        item {
+            FoodSpotImagePager(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(4f / 3f)
+                        .heightIn(max = 500.dp),
+                pagerState = imagePagerState,
+                images = foodSpotReviewState.foodSpotsPhotos,
+                onImageClick = { position ->
+                    onImageClick(position)
+                },
+            )
+            HorizontalDivider(
+                thickness = 1.dp,
+                color = Gray4,
+            )
+        }
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+            TitleAndCategory(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                title = foodSpotReviewState.name,
+                isFoodTruck = foodSpotReviewState.movableFoodSpots,
+                categories = foodSpotReviewState.categories,
+            )
+        }
+
+        if (foodSpotReviewState.reviewCount > 0) {
+            item {
+                Spacer(modifier = Modifier.height(24.dp))
+                ReviewTotal(
+                    modifier =
+                        Modifier.padding(
+                            horizontal = 16.dp,
+                        ),
+                    averageRating = foodSpotReviewState.averageRating,
+                    reviewCount = foodSpotReviewState.reviewCount,
+                    isReadMoreVisible = false,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            itemsIndexed(foodSpotReviewState.ratingCounts) { idx, ratingCount ->
+                RatingRatio(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    ratingCount = ratingCount,
+                    totalCount = foodSpotReviewState.reviewCount,
+                )
+                if (idx < foodSpotReviewState.ratingCounts.lastIndex) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(24.dp))
+            ReviewRequest(
+                modifier = Modifier.fillMaxWidth(),
+                onPostReviewClick = onPostReviewClick,
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        itemsIndexed(foodSpotReviewState.reviews) { idx, review ->
+            ReviewItem(
+                review = review.review,
+                onImageClick = { _, position ->
+                    onImageClick(position)
+                },
+                isContentExpended = review.isExpended,
+                onContentClick = {
+                    onReviewContentClick(idx)
+                },
+                onReadMoreClick = {
+                    onReviewContentReadMoreClick(idx)
+                },
+            )
+            if (idx < foodSpotReviewState.reviews.lastIndex) {
+                HorizontalDivider(
+                    modifier =
+                        Modifier.padding(
+                            horizontal = 16.dp,
+                        ),
+                    thickness = 1.dp,
+                    color = Gray4,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RatingRatio(
+    modifier: Modifier = Modifier,
+    ratingCount: RatingCount,
+    totalCount: Int,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            modifier = Modifier.size(16.dp),
+            painter = painterResource(id = R.drawable.ic_star),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.tertiary,
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = ratingCount.rating.toString(),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.tertiary,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Box(
+            modifier =
+                Modifier
+                    .clip(RoundedCornerShape(20.dp))
+                    .height(12.dp)
+                    .weight(1f)
+                    .background(Gray5),
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.CenterStart)
+                        .clip(RoundedCornerShape(20.dp))
+                        .fillMaxHeight()
+                        .fillMaxWidth(ratingCount.count / totalCount.toFloat())
+                        .background(MaterialTheme.colorScheme.primary),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun RatingRatioPreview() {
+    RoadyFoodyTheme {
+        RatingRatio(
+            modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface),
+            ratingCount =
+                RatingCount(
+                    rating = 5,
+                    count = 30,
+                ),
+            totalCount = 100,
+        )
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewSideEffect.kt
@@ -1,0 +1,11 @@
+package com.weit2nd.presentation.ui.foodspot.review
+
+import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
+
+sealed interface FoodSpotReviewSideEffect {
+    data class NavToPostReview(
+        val foodSpotForReviewDTO: FoodSpotForReviewDTO,
+    ) : FoodSpotReviewSideEffect
+
+    data object ShowNetworkErrorMessage : FoodSpotReviewSideEffect
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewState.kt
@@ -1,0 +1,17 @@
+package com.weit2nd.presentation.ui.foodspot.review
+
+import com.weit2nd.domain.model.spot.FoodCategory
+import com.weit2nd.domain.model.spot.RatingCount
+import com.weit2nd.presentation.model.reivew.ExpendableReview
+
+data class FoodSpotReviewState(
+    val id: Long = 0,
+    val name: String = "",
+    val foodSpotsPhotos: List<String> = emptyList(),
+    val movableFoodSpots: Boolean = false,
+    val categories: List<FoodCategory> = emptyList(),
+    val reviewCount: Int = 0,
+    val averageRating: Float = 0f,
+    val reviews: List<ExpendableReview> = emptyList(),
+    val ratingCounts: List<RatingCount> = emptyList(),
+)

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewViewModel.kt
@@ -1,0 +1,161 @@
+package com.weit2nd.presentation.ui.foodspot.review
+
+import androidx.lifecycle.SavedStateHandle
+import com.weit2nd.domain.model.spot.FoodSpotReview
+import com.weit2nd.domain.model.spot.ReviewSortType
+import com.weit2nd.domain.usecase.spot.GetFoodSpotReviewsUseCase
+import com.weit2nd.presentation.base.BaseViewModel
+import com.weit2nd.presentation.model.foodspot.Review
+import com.weit2nd.presentation.model.reivew.ExpendableReview
+import com.weit2nd.presentation.navigation.dto.FoodSpotReviewDTO
+import com.weit2nd.presentation.navigation.dto.toFoodCategory
+import com.weit2nd.presentation.navigation.dto.toRatingCount
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.viewmodel.container
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+
+@HiltViewModel
+class FoodSpotReviewViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val getFoodSpotReviewsUseCase: GetFoodSpotReviewsUseCase,
+) : BaseViewModel<FoodSpotReviewState, FoodSpotReviewSideEffect>() {
+    private val foodSpotReviewDTO = savedStateHandle.get<FoodSpotReviewDTO>("")!!
+    override val container: Container<FoodSpotReviewState, FoodSpotReviewSideEffect> =
+        container(
+            FoodSpotReviewState(
+                id = foodSpotReviewDTO.id,
+                name = foodSpotReviewDTO.name,
+                foodSpotsPhotos = foodSpotReviewDTO.foodSpotsPhotos,
+                movableFoodSpots = foodSpotReviewDTO.movableFoodSpots,
+                categories = foodSpotReviewDTO.categories.map { it.toFoodCategory() },
+                reviewCount = foodSpotReviewDTO.reviewCount,
+                averageRating = foodSpotReviewDTO.averageRating,
+                ratingCounts =
+                    foodSpotReviewDTO.ratingCounts
+                        .map { it.toRatingCount() }
+                        .sortedBy { it.rating },
+            ),
+        )
+    private var hasNext = AtomicBoolean(true)
+    private var requestReviewJob: Job =
+        Job().apply {
+            complete()
+        }
+
+    fun onCreate() {
+        requestReviewJob = FoodSpotReviewIntent.LoadNextReviews(null).post()
+    }
+
+    fun onImageClick(position: Int) {
+        // TODO 사진 상세 화면 이동
+    }
+
+    fun onPostReviewClick() {
+        FoodSpotReviewIntent.NavToPostReview.post()
+    }
+
+    fun onLastVisibleItemChanged(
+        totalSize: Int,
+        currentPosition: Int,
+    ) {
+        val needNextPage = (totalSize - currentPosition) <= REMAINING_PAGE_FOR_REQUEST
+        val isRequestEnable = requestReviewJob.isCompleted && needNextPage && hasNext.get()
+        if (isRequestEnable) {
+            container.stateFlow.value.reviews.lastOrNull()?.let {
+                requestReviewJob = FoodSpotReviewIntent.LoadNextReviews(it.review.reviewId).post()
+            }
+        }
+    }
+
+    fun onReviewContentsClick(position: Int) {
+        FoodSpotReviewIntent
+            .ChangeReviewContentExpendState(
+                position = position,
+                expandState = false,
+            ).post()
+    }
+
+    fun onReviewContentsReadMoreClick(position: Int) {
+        FoodSpotReviewIntent
+            .ChangeReviewContentExpendState(
+                position = position,
+                expandState = true,
+            ).post()
+    }
+
+    private fun FoodSpotReviewIntent.post() =
+        intent {
+            when (this@post) {
+                FoodSpotReviewIntent.NavToPostReview -> {
+                }
+                is FoodSpotReviewIntent.ChangeReviewContentExpendState -> {
+                    val updatedReviews =
+                        state.reviews
+                            .mapIndexed { index, review ->
+                                if (index == position) {
+                                    review.copy(
+                                        isExpended = expandState,
+                                    )
+                                } else {
+                                    review
+                                }
+                            }
+                    reduce {
+                        state.copy(
+                            reviews = updatedReviews,
+                        )
+                    }
+                }
+
+                is FoodSpotReviewIntent.LoadNextReviews -> {
+                    runCatching {
+                        getFoodSpotReviewsUseCase.invoke(
+                            foodSpotsId = 0L,
+                            count = DEFAULT_LOAD_REVIEW_COUNT,
+                            lastItemId = lastId,
+                            sortType = ReviewSortType.LATEST,
+                        )
+                    }.onSuccess { foodSpotReviews ->
+                        val reviews = foodSpotReviews.reviews.toReviews()
+                        reduce {
+                            hasNext.set(foodSpotReviews.hasNext)
+                            state.copy(
+                                reviews = reviews,
+                            )
+                        }
+                    }.onFailure {
+                        postSideEffect(FoodSpotReviewSideEffect.ShowNetworkErrorMessage)
+                    }
+                }
+            }
+        }
+
+    private fun FoodSpotReview.toReview() =
+        ExpendableReview(
+            review =
+                Review(
+                    reviewId = id,
+                    userId = userInfo.id,
+                    profileImage = userInfo.profileImage,
+                    nickname = userInfo.nickname,
+                    date = createdAt,
+                    rating = rate.toFloat(),
+                    reviewImages = photos.map { it.image },
+                    contents = contents,
+                ),
+            isExpended = false,
+        )
+
+    private fun List<FoodSpotReview>.toReviews() =
+        map {
+            it.toReview()
+        }
+
+    companion object {
+        private const val DEFAULT_LOAD_REVIEW_COUNT = 10
+        private const val REMAINING_PAGE_FOR_REQUEST = 3
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewViewModel.kt
@@ -8,6 +8,7 @@ import com.weit2nd.presentation.base.BaseViewModel
 import com.weit2nd.presentation.model.foodspot.Review
 import com.weit2nd.presentation.model.reivew.ExpendableReview
 import com.weit2nd.presentation.navigation.FoodSpotReviewRoutes
+import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
 import com.weit2nd.presentation.navigation.dto.FoodSpotReviewDTO
 import com.weit2nd.presentation.navigation.dto.toFoodCategory
 import com.weit2nd.presentation.navigation.dto.toRatingCount
@@ -91,6 +92,12 @@ class FoodSpotReviewViewModel @Inject constructor(
         intent {
             when (this@post) {
                 FoodSpotReviewIntent.NavToPostReview -> {
+                    val foodSpotForReviewDTO =
+                        FoodSpotForReviewDTO(
+                            id = state.id,
+                            name = state.name,
+                        )
+                    postSideEffect(FoodSpotReviewSideEffect.NavToPostReview(foodSpotForReviewDTO))
                 }
                 is FoodSpotReviewIntent.ChangeReviewContentExpendState -> {
                     val updatedReviews =

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/review/FoodSpotReviewViewModel.kt
@@ -7,6 +7,7 @@ import com.weit2nd.domain.usecase.spot.GetFoodSpotReviewsUseCase
 import com.weit2nd.presentation.base.BaseViewModel
 import com.weit2nd.presentation.model.foodspot.Review
 import com.weit2nd.presentation.model.reivew.ExpendableReview
+import com.weit2nd.presentation.navigation.FoodSpotReviewRoutes
 import com.weit2nd.presentation.navigation.dto.FoodSpotReviewDTO
 import com.weit2nd.presentation.navigation.dto.toFoodCategory
 import com.weit2nd.presentation.navigation.dto.toRatingCount
@@ -22,7 +23,7 @@ class FoodSpotReviewViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val getFoodSpotReviewsUseCase: GetFoodSpotReviewsUseCase,
 ) : BaseViewModel<FoodSpotReviewState, FoodSpotReviewSideEffect>() {
-    private val foodSpotReviewDTO = savedStateHandle.get<FoodSpotReviewDTO>("")!!
+    private val foodSpotReviewDTO = savedStateHandle.get<FoodSpotReviewDTO>(FoodSpotReviewRoutes.FOOD_SPOT_REVIEW_KEY)!!
     override val container: Container<FoodSpotReviewState, FoodSpotReviewSideEffect> =
         container(
             FoodSpotReviewState(
@@ -113,7 +114,7 @@ class FoodSpotReviewViewModel @Inject constructor(
                 is FoodSpotReviewIntent.LoadNextReviews -> {
                     runCatching {
                         getFoodSpotReviewsUseCase.invoke(
-                            foodSpotsId = 0L,
+                            foodSpotsId = state.id,
                             count = DEFAULT_LOAD_REVIEW_COUNT,
                             lastItemId = lastId,
                             sortType = ReviewSortType.LATEST,

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -101,7 +101,7 @@
     <string name="food_spot_detail_post_review_button">리뷰 작성하기</string>
     <string name="food_spot_detail_review_count">리뷰 %d</string>
     <string name="food_spot_detail_view_more_review">리뷰 더보기</string>
-    <string name="food_spot_detail_operation_hour_close_time">%d:%.2d 까지</string>
+    <string name="food_spot_detail_operation_hour_close_time">%d:%02d 까지</string>
 
     <!-- post review -->
     <string name="post_review_title">리뷰를 남겨주세요!</string>


### PR DESCRIPTION
### 개요
* 리뷰 전체 보기 화면

### 변경사항
- 리뷰 전체 보기 화면 개발
- 음식점 상세 화면 수정
  - 공통 컴포넌트 분리
  - 영업 시간 표시 포맷 수정 (이전엔 왜 됐는지 모르겠음)
  - 리뷰 총 개수, 평균 별점 제대로 표시
- 음식점 상세 api 응답 필드 업데이트

### 관련 지라 및 위키 링크
 - [ROFO-216](https://weit-2nd.atlassian.net/browse/ROFO-216) 

### 프리뷰
![미디어 (78)](https://github.com/user-attachments/assets/04c2d5c5-9c04-4966-b0a9-c5662f3577db)


### 리뷰어에게 하고 싶은 말
- 변경이 꽤 많아보이는데 대부분 FoodSpotDetailScreen의 컴포저블을 common으로 옮긴다고 생긴 변경임
- 대부분 이전에 있던 컴포저블을 그대로 가져다 쓰니까 편하네용

[ROFO-216]: https://weit-2nd.atlassian.net/browse/ROFO-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ