### PR TITLE
ROFO-226 마이페이지 로딩 및 컨텐트 이동

### DIFF
--- a/data/src/main/java/com/weit2nd/data/model/spot/FoodSpotHistoriesDTO.kt
+++ b/data/src/main/java/com/weit2nd/data/model/spot/FoodSpotHistoriesDTO.kt
@@ -23,4 +23,5 @@ data class FoodSpotHistoryContentDTO(
     @field:Json(name = "createdDateTime") @StringToLocalDateTime val createdDateTime: LocalDateTime,
     @field:Json(name = "reportPhotos") val reportPhotos: List<FoodSpotPhotoDTO>,
     @field:Json(name = "categories") val categories: List<FoodCategoryDTO>,
+    @field:Json(name = "foodTruck") val isFoodTruck: Boolean,
 )

--- a/data/src/main/java/com/weit2nd/data/repository/user/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/weit2nd/data/repository/user/UserRepositoryImpl.kt
@@ -101,5 +101,6 @@ class UserRepositoryImpl @Inject constructor(
             createdDateTime = createdDateTime,
             reportPhotos = reportPhotos.map { it.toFoodSpotPhoto() },
             categories = categories.map { it.toFoodCategory() },
+            isFoodTruck = isFoodTruck,
         )
 }

--- a/domain/src/main/java/com/weit2nd/domain/model/spot/FoodSpotHistories.kt
+++ b/domain/src/main/java/com/weit2nd/domain/model/spot/FoodSpotHistories.kt
@@ -17,4 +17,5 @@ data class FoodSpotHistoryContent(
     val createdDateTime: LocalDateTime,
     val reportPhotos: List<FoodSpotPhoto>,
     val categories: List<FoodCategory>,
+    val isFoodTruck: Boolean,
 )

--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -308,6 +308,9 @@ private fun NavGraphBuilder.myPageComposable(navController: NavHostController) {
             navToFoodSpotHistory = { userId ->
                 navController.navigateToFoodSpotHistory(userId)
             },
+            navToFoodSpotDetail = { foodSpotId ->
+                navController.navigateToFoodSpotDetail(foodSpotId)
+            },
         )
     }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/FoodSpotItem.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/FoodSpotItem.kt
@@ -59,14 +59,14 @@ fun FoodSpotItem(
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
-//                if (isFoodTruck) { // todo api 수정되면 푸드트럭 여부 화면에 반영
-//                    Spacer(modifier = Modifier.width(4.dp))
-//                    Icon(
-//                        painter = painterResource(id = R.drawable.ic_truck),
-//                        contentDescription = "food truck",
-//                        tint = MaterialTheme.colorScheme.secondary,
-//                    )
-//                }
+                if (foodSpot.isFoodTruck) {
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_truck),
+                        contentDescription = "food truck",
+                        tint = MaterialTheme.colorScheme.secondary,
+                    )
+                }
             }
             Spacer(modifier = Modifier.height(4.dp))
             FoodCategory(categories = foodSpot.categories)
@@ -176,6 +176,7 @@ private fun FoodSpotItemPreview() {
                     latitude = 45.55,
                     createdDateTime = LocalDateTime.now(),
                     reportPhotos = listOf(),
+                    isFoodTruck = true,
                     categories =
                         listOf(
                             FoodCategory(

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/FoodSpotItem.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/FoodSpotItem.kt
@@ -62,6 +62,7 @@ fun FoodSpotItem(
                 if (foodSpot.isFoodTruck) {
                     Spacer(modifier = Modifier.width(4.dp))
                     Icon(
+                        modifier = Modifier.size(16.dp),
                         painter = painterResource(id = R.drawable.ic_truck),
                         contentDescription = "food truck",
                         tint = MaterialTheme.colorScheme.secondary,

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageIntent.kt
@@ -15,6 +15,10 @@ sealed class MyPageIntent {
 
     data object NavToFoodSpotHistory : MyPageIntent()
 
+    data class NavToFoodSpotDetail(
+        val foodSpotId: Long,
+    ) : MyPageIntent()
+
     data object Logout : MyPageIntent()
 
     data object Withdraw : MyPageIntent()

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageScreen.kt
@@ -393,6 +393,7 @@ private fun MyPageContentPreview() {
                     latitude = 10.11,
                     createdDateTime = LocalDateTime.now(),
                     reportPhotos = listOf(FoodSpotPhoto(0, "")),
+                    isFoodTruck = true,
                     categories =
                         listOf(
                             com.weit2nd.domain.model.spot

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageScreen.kt
@@ -95,45 +95,47 @@ fun MyPageScreen(
         vm.onCreate()
     }
 
-    if (state.isLoading) {
-        LoadingDialogScreen()
-    }
+    Box {
+        if (state.isLoading) {
+            LoadingDialogScreen()
+        }
 
-    Scaffold(
-        topBar = {
-            BackTopBar(
-                title = stringResource(R.string.my_page_toolbar_title),
-                onClickBackBtn = vm::onBackButtonClick,
-            )
-        },
-    ) {
-        LazyColumn(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(it),
-        ) {
-            item {
-                MyPageContent(
-                    profileImage = state.profileImage,
-                    nickname = state.nickname,
-                    coin = state.coin,
-                    foodSpotHistory = state.foodSpotHistory,
-                    review = state.review,
-                    onLogoutButtonClick = vm::onLogoutButtonClick,
-                    onWithdrawButtonClick = vm::onWithdrawButtonClick,
-                    onLogoutConfirm = vm::onLogoutConfirm,
-                    onWithdrawConfirm = vm::onWithdrawConfirm,
-                    onLogoutDialogClose = vm::onLogoutDialogClose,
-                    onWithdrawDialogClose = vm::onWithdrawDialogClose,
-                    isLogoutDialogShown = state.isLogoutDialogShown,
-                    isWithdrawDialogShown = state.isWithdrawDialogShown,
-                    onFoodSpotHistoryClick = vm::onFoodSpotHistoryClick,
-                    onFoodSpotContentClick = vm::onFoodSpotContentClick,
-                    onReviewHistoryClick = vm::onReviewHistoryClick,
-                    foodSpotCount = state.foodSpotCount,
-                    reviewCount = state.reviewCount,
+        Scaffold(
+            topBar = {
+                BackTopBar(
+                    title = stringResource(R.string.my_page_toolbar_title),
+                    onClickBackBtn = vm::onBackButtonClick,
                 )
+            },
+        ) {
+            LazyColumn(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(it),
+            ) {
+                item {
+                    MyPageContent(
+                        profileImage = state.profileImage,
+                        nickname = state.nickname,
+                        coin = state.coin,
+                        foodSpotHistory = state.foodSpotHistory,
+                        review = state.review,
+                        onLogoutButtonClick = vm::onLogoutButtonClick,
+                        onWithdrawButtonClick = vm::onWithdrawButtonClick,
+                        onLogoutConfirm = vm::onLogoutConfirm,
+                        onWithdrawConfirm = vm::onWithdrawConfirm,
+                        onLogoutDialogClose = vm::onLogoutDialogClose,
+                        onWithdrawDialogClose = vm::onWithdrawDialogClose,
+                        isLogoutDialogShown = state.isLogoutDialogShown,
+                        isWithdrawDialogShown = state.isWithdrawDialogShown,
+                        onFoodSpotHistoryClick = vm::onFoodSpotHistoryClick,
+                        onFoodSpotContentClick = vm::onFoodSpotContentClick,
+                        onReviewHistoryClick = vm::onReviewHistoryClick,
+                        foodSpotCount = state.foodSpotCount,
+                        reviewCount = state.reviewCount,
+                    )
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageScreen.kt
@@ -40,6 +40,7 @@ import com.weit2nd.presentation.navigation.dto.ReviewHistoryDTO
 import com.weit2nd.presentation.ui.common.BackTopBar
 import com.weit2nd.presentation.ui.common.CommonAlertDialog
 import com.weit2nd.presentation.ui.common.EditableProfileImage
+import com.weit2nd.presentation.ui.common.LoadingDialogScreen
 import com.weit2nd.presentation.ui.common.ReviewItem
 import com.weit2nd.presentation.ui.theme.DarkGray
 import com.weit2nd.presentation.ui.theme.Gray1
@@ -87,6 +88,10 @@ fun MyPageScreen(
 
     LaunchedEffect(Unit) {
         vm.onCreate()
+    }
+
+    if (state.isLoading) {
+        LoadingDialogScreen()
     }
 
     Scaffold(

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageScreen.kt
@@ -58,6 +58,7 @@ fun MyPageScreen(
     navToReviewHistory: (ReviewHistoryDTO) -> Unit,
     navToBack: () -> Unit,
     navToFoodSpotHistory: (Long) -> Unit,
+    navToFoodSpotDetail: (Long) -> Unit,
     vm: MyPageViewModel = hiltViewModel(),
 ) {
     val state by vm.collectAsState()
@@ -82,6 +83,10 @@ fun MyPageScreen(
 
             MyPageSideEffect.NavToBack -> {
                 navToBack()
+            }
+
+            is MyPageSideEffect.NavToFoodSpotDetail -> {
+                navToFoodSpotDetail(sideEffect.foodSpotId)
             }
         }
     }
@@ -124,6 +129,7 @@ fun MyPageScreen(
                     isLogoutDialogShown = state.isLogoutDialogShown,
                     isWithdrawDialogShown = state.isWithdrawDialogShown,
                     onFoodSpotHistoryClick = vm::onFoodSpotHistoryClick,
+                    onFoodSpotContentClick = vm::onFoodSpotContentClick,
                     onReviewHistoryClick = vm::onReviewHistoryClick,
                     foodSpotCount = state.foodSpotCount,
                     reviewCount = state.reviewCount,
@@ -150,6 +156,7 @@ private fun MyPageContent(
     isLogoutDialogShown: Boolean,
     isWithdrawDialogShown: Boolean,
     onFoodSpotHistoryClick: () -> Unit,
+    onFoodSpotContentClick: (Long) -> Unit,
     onReviewHistoryClick: () -> Unit,
     foodSpotCount: Int,
     reviewCount: Int,
@@ -204,6 +211,7 @@ private fun MyPageContent(
                         .padding(horizontal = 16.dp),
                 foodSpotHistory = foodSpotHistory,
                 onFoodSpotHistoryClick = onFoodSpotHistoryClick,
+                onFoodSpotContentClick = onFoodSpotContentClick,
                 foodSpotCount = foodSpotCount,
             )
 
@@ -274,6 +282,7 @@ private fun ReportedFoodSpot(
     modifier: Modifier = Modifier,
     foodSpotHistory: FoodSpotHistoryContent?,
     onFoodSpotHistoryClick: () -> Unit,
+    onFoodSpotContentClick: (Long) -> Unit,
     foodSpotCount: Int,
 ) {
     Row(
@@ -301,7 +310,10 @@ private fun ReportedFoodSpot(
         }
     }
     if (foodSpotHistory != null) {
-        FoodSpotItem(foodSpot = foodSpotHistory)
+        FoodSpotItem(
+            modifier = Modifier.clickable { onFoodSpotContentClick(foodSpotHistory.foodSpotsId) },
+            foodSpot = foodSpotHistory,
+        )
     } else {
         Text(
             modifier = Modifier.padding(vertical = 32.dp),
@@ -428,6 +440,7 @@ private fun MyPageContentPreview() {
             onFoodSpotHistoryClick = {},
             reviewCount = 2,
             foodSpotCount = 3,
+            onFoodSpotContentClick = { _ -> },
         )
     }
 }
@@ -455,6 +468,7 @@ private fun MyPageNoContentPreview() {
             onFoodSpotHistoryClick = {},
             reviewCount = 0,
             foodSpotCount = 0,
+            onFoodSpotContentClick = { _ -> },
         )
     }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageSideEffect.kt
@@ -18,4 +18,8 @@ sealed class MyPageSideEffect {
     data class NavToFoodSpotHistory(
         val userId: Long,
     ) : MyPageSideEffect()
+
+    data class NavToFoodSpotDetail(
+        val foodSpotId: Long,
+    ) : MyPageSideEffect()
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageState.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageState.kt
@@ -4,6 +4,7 @@ import com.weit2nd.domain.model.spot.FoodSpotHistoryContent
 import com.weit2nd.presentation.model.foodspot.Review
 
 data class MyPageState(
+    val isLoading: Boolean = false,
     val userId: Long = 0,
     val profileImage: String? = null,
     val nickname: String = "",

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageViewModel.kt
@@ -69,6 +69,11 @@ class MyPageViewModel @Inject constructor(
         intent {
             when (this@post) {
                 MyPageIntent.GetMyUserInfo -> {
+                    reduce {
+                        state.copy(
+                            isLoading = true,
+                        )
+                    }
                     coroutineScope {
                         runCatching {
                             val userInfo = getMyUserInfoUseCase.invoke()
@@ -113,6 +118,7 @@ class MyPageViewModel @Inject constructor(
                                                 writtenReview.contents,
                                             )
                                         },
+                                    isLoading = false,
                                 )
                             }
                         }.onFailure { postSideEffect(MyPageSideEffect.ShowToastMessage("네트워크 오류가 발생했습니다.")) }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageViewModel.kt
@@ -121,7 +121,10 @@ class MyPageViewModel @Inject constructor(
                                     isLoading = false,
                                 )
                             }
-                        }.onFailure { postSideEffect(MyPageSideEffect.ShowToastMessage("네트워크 오류가 발생했습니다.")) }
+                        }.onFailure {
+                            postSideEffect(MyPageSideEffect.ShowToastMessage("네트워크 오류가 발생했습니다."))
+                            postSideEffect(MyPageSideEffect.NavToBack)
+                        }
                     }
                 }
 

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/mypage/MyPageViewModel.kt
@@ -65,6 +65,10 @@ class MyPageViewModel @Inject constructor(
         MyPageIntent.NavToFoodSpotHistory.post()
     }
 
+    fun onFoodSpotContentClick(foodSpotId: Long) {
+        MyPageIntent.NavToFoodSpotDetail(foodSpotId).post()
+    }
+
     private fun MyPageIntent.post() =
         intent {
             when (this@post) {
@@ -186,6 +190,10 @@ class MyPageViewModel @Inject constructor(
 
                 MyPageIntent.NavToFoodSpotHistory -> {
                     postSideEffect(MyPageSideEffect.NavToFoodSpotHistory(state.userId))
+                }
+
+                is MyPageIntent.NavToFoodSpotDetail -> {
+                    postSideEffect(MyPageSideEffect.NavToFoodSpotDetail(foodSpotId))
                 }
             }
         }


### PR DESCRIPTION
### 개요
- 마이페이지 로딩
- 제보 음식점 클릭 시 상세 화면으로 이동

### 변경사항
- 마이페이지 처음 들어갔을 때 로딩 다이얼로그 표시
- 로드 실패 시 화면 빠져나가기
- 내가 제보한 음식점 클릭 시 상세 화면으로 이동
- 푸드트럭 여부 추가된 api 반영

### 관련 지라 및 위키 링크
 - [JIRA 226](https://weit-2nd.atlassian.net/browse/ROFO-226) 

### 로딩화면
![Sep-21-2024 21-21-00](https://github.com/user-attachments/assets/d5e42df6-1bfa-45d8-8413-9a1299205d91)
