### PR TITLE
ROFO-219 음식점 상세 화면 개선

### DIFF
--- a/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/navigation/AppNavHost.kt
@@ -417,6 +417,12 @@ private fun NavGraphBuilder.foodSpotDetailComposable(navController: NavHostContr
             navToFoodSpotReview = {
                 navController.navigateToFoodSpotReview(it)
             },
+            navToImageViewer = {
+                navController.navigateToImageViewer(
+                    it.images,
+                    it.position,
+                )
+            },
         )
     }
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/common/RetryScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/common/RetryScreen.kt
@@ -1,0 +1,28 @@
+package com.weit2nd.presentation.ui.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun RetryScreen(
+    modifier: Modifier = Modifier,
+    onRetryButtonClick: () -> Unit,
+) {
+    // TODO 디자인 적용
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Button(
+            onClick = onRetryButtonClick,
+        ) {
+            Text(text = "재시도")
+        }
+    }
+}

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailIntent.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailIntent.kt
@@ -25,4 +25,9 @@ sealed interface FoodSpotDetailIntent {
     ) : FoodSpotDetailIntent
 
     data object NavToFoodSpotReview : FoodSpotDetailIntent
+
+    data class NavToImageViewer(
+        val images: List<String>,
+        val position: Int,
+    ) : FoodSpotDetailIntent
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
@@ -61,6 +61,7 @@ import com.weit2nd.presentation.R
 import com.weit2nd.presentation.model.foodspot.OperationHour
 import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
 import com.weit2nd.presentation.navigation.dto.FoodSpotReviewDTO
+import com.weit2nd.presentation.navigation.dto.ImageViewerDTO
 import com.weit2nd.presentation.ui.common.BorderButton
 import com.weit2nd.presentation.ui.common.FoodSpotImagePager
 import com.weit2nd.presentation.ui.common.LoadingDialogScreen
@@ -84,6 +85,7 @@ fun FoodSpotDetailScreen(
     navToBack: () -> Unit,
     navToPostReview: (FoodSpotForReviewDTO) -> Unit,
     navToFoodSpotReview: (FoodSpotReviewDTO) -> Unit,
+    navToImageViewer: (ImageViewerDTO) -> Unit,
 ) {
     val state by vm.collectAsState()
 
@@ -116,6 +118,10 @@ fun FoodSpotDetailScreen(
 
             is FoodSpotDetailSideEffect.NavToFoodSpotReview -> {
                 navToFoodSpotReview(sideEffect.foodSpotReviewDTO)
+            }
+
+            is FoodSpotDetailSideEffect.NavToImageViewer -> {
+                navToImageViewer(sideEffect.imageViewerDTO)
             }
         }
     }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
@@ -62,6 +62,7 @@ import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
 import com.weit2nd.presentation.navigation.dto.FoodSpotReviewDTO
 import com.weit2nd.presentation.ui.common.BorderButton
 import com.weit2nd.presentation.ui.common.FoodSpotImagePager
+import com.weit2nd.presentation.ui.common.LoadingDialogScreen
 import com.weit2nd.presentation.ui.common.ReviewItem
 import com.weit2nd.presentation.ui.common.ReviewRequest
 import com.weit2nd.presentation.ui.common.ReviewTotal
@@ -150,18 +151,23 @@ fun FoodSpotDetailScreen(
             state.openState != FoodSpotOpenState.UNKNOWN
         }
     }
-    FoodSpotDetailContent(
-        state = state,
-        mapView = mapView,
-        isViewMoreOperationHoursEnabled = isViewMoreOperationHoursEnabled,
-        isBusinessInformationShow = isBusinessInformationShow,
-        onImageClick = vm::onImageClick,
-        onOperationHourClick = vm::onOperationHourClick,
-        onPostReviewClick = vm::onPostReviewClick,
-        onReviewContentClick = vm::onReviewContentsClick,
-        onReviewContentReadMoreClick = vm::onReviewContentsReadMoreClick,
-        onReviewReadMoreClick = vm::onReviewReadMoreClick,
-    )
+    Box {
+        if (state.isLoading) {
+            LoadingDialogScreen()
+        }
+        FoodSpotDetailContent(
+            state = state,
+            mapView = mapView,
+            isViewMoreOperationHoursEnabled = isViewMoreOperationHoursEnabled,
+            isBusinessInformationShow = isBusinessInformationShow,
+            onImageClick = vm::onImageClick,
+            onOperationHourClick = vm::onOperationHourClick,
+            onPostReviewClick = vm::onPostReviewClick,
+            onReviewContentClick = vm::onReviewContentsClick,
+            onReviewContentReadMoreClick = vm::onReviewContentsReadMoreClick,
+            onReviewReadMoreClick = vm::onReviewReadMoreClick,
+        )
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -190,10 +196,10 @@ private fun FoodSpotDetailContent(
         item {
             FoodSpotImagePager(
                 modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(4f / 3f)
-                        .heightIn(max = 500.dp),
+                Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(4f / 3f)
+                    .heightIn(max = 500.dp),
                 pagerState = imagePagerState,
                 images = state.foodSpotsPhotos,
                 onImageClick = { position ->

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
@@ -65,6 +65,7 @@ import com.weit2nd.presentation.navigation.dto.ImageViewerDTO
 import com.weit2nd.presentation.ui.common.BorderButton
 import com.weit2nd.presentation.ui.common.FoodSpotImagePager
 import com.weit2nd.presentation.ui.common.LoadingDialogScreen
+import com.weit2nd.presentation.ui.common.RetryScreen
 import com.weit2nd.presentation.ui.common.ReviewItem
 import com.weit2nd.presentation.ui.common.ReviewRequest
 import com.weit2nd.presentation.ui.common.ReviewTotal
@@ -162,18 +163,25 @@ fun FoodSpotDetailScreen(
         if (state.isLoading) {
             LoadingDialogScreen()
         }
-        FoodSpotDetailContent(
-            state = state,
-            mapView = mapView,
-            isViewMoreOperationHoursEnabled = isViewMoreOperationHoursEnabled,
-            isBusinessInformationShow = isBusinessInformationShow,
-            onImageClick = vm::onImageClick,
-            onOperationHourClick = vm::onOperationHourClick,
-            onPostReviewClick = vm::onPostReviewClick,
-            onReviewContentClick = vm::onReviewContentsClick,
-            onReviewContentReadMoreClick = vm::onReviewContentsReadMoreClick,
-            onReviewReadMoreClick = vm::onReviewReadMoreClick,
-        )
+        if (state.shouldRetry) {
+            RetryScreen(
+                modifier = Modifier.fillMaxSize(),
+                onRetryButtonClick = vm::onRetryButtonClick,
+            )
+        } else {
+            FoodSpotDetailContent(
+                state = state,
+                mapView = mapView,
+                isViewMoreOperationHoursEnabled = isViewMoreOperationHoursEnabled,
+                isBusinessInformationShow = isBusinessInformationShow,
+                onImageClick = vm::onImageClick,
+                onOperationHourClick = vm::onOperationHourClick,
+                onPostReviewClick = vm::onPostReviewClick,
+                onReviewContentClick = vm::onReviewContentsClick,
+                onReviewContentReadMoreClick = vm::onReviewContentsReadMoreClick,
+                onReviewReadMoreClick = vm::onReviewReadMoreClick,
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailScreen.kt
@@ -3,6 +3,7 @@ package com.weit2nd.presentation.ui.foodspot.detail
 import android.content.Context
 import android.graphics.PointF
 import android.util.Log
+import android.view.ViewGroup
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -275,7 +276,10 @@ private fun FoodSpotDetailContent(
                             .clip(RoundedCornerShape(12.dp))
                             .aspectRatio(4f / 3f)
                             .fillMaxWidth(),
-                    factory = { mapView },
+                    factory = {
+                        (mapView.parent as? ViewGroup)?.removeView(mapView)
+                        mapView
+                    },
                 )
             }
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailSideEffect.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailSideEffect.kt
@@ -4,6 +4,7 @@ import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.LatLng
 import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
 import com.weit2nd.presentation.navigation.dto.FoodSpotReviewDTO
+import com.weit2nd.presentation.navigation.dto.ImageViewerDTO
 
 sealed interface FoodSpotDetailSideEffect {
     data object NavToBack : FoodSpotDetailSideEffect
@@ -19,5 +20,9 @@ sealed interface FoodSpotDetailSideEffect {
 
     data class NavToFoodSpotReview(
         val foodSpotReviewDTO: FoodSpotReviewDTO,
+    ) : FoodSpotDetailSideEffect
+
+    data class NavToImageViewer(
+        val imageViewerDTO: ImageViewerDTO,
     ) : FoodSpotDetailSideEffect
 }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailViewModel.kt
@@ -52,6 +52,14 @@ class FoodSpotDetailViewModel @Inject constructor(
         }
     }
 
+    fun onRetryButtonClick() {
+        if (foodSpotId != null) {
+            FoodSpotDetailIntent.LoadFoodSpotDetail(foodSpotId).post()
+        } else {
+            FoodSpotDetailIntent.NavToBack.post()
+        }
+    }
+
     fun onImageClick(
         images: List<String>,
         position: Int,

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailViewModel.kt
@@ -18,6 +18,7 @@ import com.weit2nd.presentation.model.reivew.ExpendableReview
 import com.weit2nd.presentation.navigation.FoodSpotDetailRoutes
 import com.weit2nd.presentation.navigation.dto.FoodSpotForReviewDTO
 import com.weit2nd.presentation.navigation.dto.FoodSpotReviewDTO
+import com.weit2nd.presentation.navigation.dto.ImageViewerDTO
 import com.weit2nd.presentation.navigation.dto.toFoodCategoryDTO
 import com.weit2nd.presentation.navigation.dto.toRatingCountDTO
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -55,7 +56,11 @@ class FoodSpotDetailViewModel @Inject constructor(
         images: List<String>,
         position: Int,
     ) {
-        // TODO ImageViewScreen 연결
+        FoodSpotDetailIntent
+            .NavToImageViewer(
+                images = images,
+                position = position,
+            ).post()
     }
 
     fun onOperationHourClick(currentOperationHourOpenState: Boolean) {
@@ -249,6 +254,15 @@ class FoodSpotDetailViewModel @Inject constructor(
                             ratingCounts = state.ratingCounts.map { it.toRatingCountDTO() },
                         )
                     postSideEffect(FoodSpotDetailSideEffect.NavToFoodSpotReview(foodSpotReviewDTO))
+                }
+
+                is FoodSpotDetailIntent.NavToImageViewer -> {
+                    val imageViewerDTO =
+                        ImageViewerDTO(
+                            images = images,
+                            position = position,
+                        )
+                    postSideEffect(FoodSpotDetailSideEffect.NavToImageViewer(imageViewerDTO))
                 }
             }
         }

--- a/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailViewModel.kt
+++ b/presentation/src/main/java/com/weit2nd/presentation/ui/foodspot/detail/FoodSpotDetailViewModel.kt
@@ -117,6 +117,28 @@ class FoodSpotDetailViewModel @Inject constructor(
                             }
                         val foodSpotReviews = foodSpotReviewsDeferred.await()
                         val detail = detailDeferred.await()
+                        reduce {
+                            state.copy(
+                                name = detail.name,
+                                position =
+                                    LatLng.from(
+                                        detail.latitude,
+                                        detail.longitude,
+                                    ),
+                                movableFoodSpots = detail.movableFoodSpots,
+                                openState = detail.openState,
+                                storeClosure = detail.storeClosure,
+                                operationHours = detail.operationHoursList.map { it.toOperationHour() },
+                                todayCloseTime = getTodayCloseTime(detail.operationHoursList),
+                                foodCategoryList = detail.foodCategoryList,
+                                foodSpotsPhotos = detail.foodSpotsPhotos.map { it.image },
+                                reviewCount = detail.reviewInfo.reviewCount,
+                                averageRating = detail.reviewInfo.average,
+                                ratingCounts = detail.ratingCounts,
+                                reviews = foodSpotReviews.reviews.map { it.toReview() },
+                                hasMoreReviews = foodSpotReviews.hasNext,
+                            )
+                        }
                         val address =
                             searchPlaceWithCoordinateUseCase(
                                 coordinate =
@@ -129,25 +151,7 @@ class FoodSpotDetailViewModel @Inject constructor(
                             }
                         reduce {
                             state.copy(
-                                name = detail.name,
-                                position =
-                                    LatLng.from(
-                                        detail.latitude,
-                                        detail.longitude,
-                                    ),
-                                movableFoodSpots = detail.movableFoodSpots,
-                                openState = detail.openState,
                                 address = address,
-                                storeClosure = detail.storeClosure,
-                                operationHours = detail.operationHoursList.map { it.toOperationHour() },
-                                todayCloseTime = getTodayCloseTime(detail.operationHoursList),
-                                foodCategoryList = detail.foodCategoryList,
-                                foodSpotsPhotos = detail.foodSpotsPhotos.map { it.image },
-                                reviewCount = detail.reviewInfo.reviewCount,
-                                averageRating = detail.reviewInfo.average,
-                                ratingCounts = detail.ratingCounts,
-                                reviews = foodSpotReviews.reviews.map { it.toReview() },
-                                hasMoreReviews = foodSpotReviews.hasNext,
                             )
                         }
                         state.map?.let { map ->


### PR DESCRIPTION
### 개요
* 음식점 상세 화면 개선

### 변경사항
- api 병렬 요청
- 영업 시간을 폈다 접었을 때 발생하는 크래쉬 수정
  - 왜 그런진 모르겠지만 영업 시간을 펴면 카카오맵이 다시 생성되면서 발생하는 오류임
- 로딩 뷰 추가
- 재시도 화면 추가
  - 화면 디자인은 작업을 벗어난다 생각해서 따로 지라 파서 진행할거심
- 이미지 뷰어 네비게이션 동작 추가

### 관련 지라 및 위키 링크
 - [ROFO-219](https://weit-2nd.atlassian.net/browse/ROFO-219) 

### 리뷰어에게 하고 싶은 말
😄 

[ROFO-219]: https://weit-2nd.atlassian.net/browse/ROFO-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ